### PR TITLE
support -noshare suffix in social element

### DIFF
--- a/packages/library/src/elements/body/mj_social/main.rs
+++ b/packages/library/src/elements/body/mj_social/main.rs
@@ -193,6 +193,14 @@ pub mod tests {
     }
 
     #[test]
+    fn link() {
+        compare_render(
+            include_str!("../../../../test/mj-social-link.mjml"),
+            include_str!("../../../../test/mj-social-link.html"),
+        );
+    }
+
+    #[test]
     fn with_align() {
         compare_render(
             include_str!("../../../../test/mj-social-align.mjml"),

--- a/packages/library/src/lib.rs
+++ b/packages/library/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(bool_to_option)]
+
 #[cfg(test)]
 #[macro_use(assert_diff)]
 extern crate difference;

--- a/packages/library/test/mj-social-link.html
+++ b/packages/library/test/mj-social-link.html
@@ -1,0 +1,171 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <title> </title>
+  <!--[if !mso]><!-- -->
+  <meta content="IE=edge" http-equiv="X-UA-Compatible">
+  <!--<![endif]-->
+  <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+  <meta content="width=device-width, initial-scale=1" name="viewport">
+  <style type="text/css">
+    #outlook a {
+      padding: 0;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
+
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+  </style>
+  <!--[if mso]>
+        <xml>
+        <o:OfficeDocumentSettings>
+          <o:AllowPNG/>
+          <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+        </xml>
+        <![endif]-->
+  <!--[if lte mso 11]>
+        <style type="text/css">
+          .mj-outlook-group-fix { width:100% !important; }
+        </style>
+        <![endif]-->
+  <!--[if !mso]><!-->
+  <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+  <style type="text/css">
+    @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+  </style>
+  <!--<![endif]-->
+  <style type="text/css">
+    @media only screen and (min-width:480px) {
+      .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div style="">
+    <!--[if mso | IE]>
+      <table
+         align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
+      >
+        <tr>
+          <td style="font-size:0px;line-height:0px;mso-line-height-rule:exactly;">
+      <![endif]-->
+    <div style="margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+              <!--[if mso | IE]>
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation">
+
+        <tr>
+
+            <td
+               class="" style="vertical-align:top;width:600px;"
+            >
+          <![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="direction:ltr;display:inline-block;font-size:0px;text-align:left;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                  <tr>
+                    <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                      <!--[if mso | IE]>
+      <table
+         align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+      >
+        <tr>
+
+              <td>
+            <![endif]-->
+                      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="display:inline-table;float:none;">
+                        <tr>
+                          <td style="padding:4px;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#3b5998;border-radius:3px;width:20px;">
+                              <tr>
+                                <td style="font-size:0;height:20px;vertical-align:middle;width:20px;"> <a href="https://www.facebook.com/sharer/sharer.php?u=mjml" target="_blank"> <img height="20" src="https://www.mailjet.com/images/theme/v1/icons/ico-social/facebook.png" style="border-radius:3px;display:block;" width="20" /> </a> </td>
+                              </tr>
+                            </table>
+                          </td>
+                          <td style="vertical-align:middle;"> <a href="https://www.facebook.com/sharer/sharer.php?u=mjml" style="color:#333333;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;text-decoration:none;" target="_blank">
+              Facebook
+            </a></td>
+                        </tr>
+                      </table>
+                      <!--[if mso | IE]>
+              </td>
+
+              <td>
+            <![endif]-->
+                      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="display:inline-table;float:none;">
+                        <tr>
+                          <td style="padding:4px;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#3b5998;border-radius:3px;width:20px;">
+                              <tr>
+                                <td style="font-size:0;height:20px;vertical-align:middle;width:20px;"> <a href="https://mjml.io/" target="_blank"><img height="20" src="https://www.mailjet.com/images/theme/v1/icons/ico-social/facebook.png" style="border-radius:3px;display:block;" width="20" /> </a> </td>
+                              </tr>
+                            </table>
+                          </td>
+                          <td style="vertical-align:middle;"> <a href="https://mjml.io/" style="color:#333333;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;text-decoration:none;" target="_blank">
+              Facebook
+            </a> </td>
+                        </tr>
+                      </table>
+                      <!--[if mso | IE]>
+              </td>
+
+          </tr>
+        </table>
+      <![endif]-->
+                    </td>
+                  </tr>
+                </table>
+              </div>
+              <!--[if mso | IE]>
+            </td>
+
+        </tr>
+
+                  </table>
+                <![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      <![endif]-->
+  </div>
+</body>
+
+</html>

--- a/packages/library/test/mj-social-link.mjml
+++ b/packages/library/test/mj-social-link.mjml
@@ -1,0 +1,16 @@
+<mjml>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-social>
+          <mj-social-element name="facebook" href="mjml">
+            Facebook
+          </mj-social-element>
+          <mj-social-element name="facebook-noshare" href="https://mjml.io/">
+            Facebook
+          </mj-social-element>
+        </mj-social>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>


### PR DESCRIPTION
Support of the small comment at the bottom of the [social element](https://mjml.io/documentation/#mj-social):

When using a network with share url, the `href` attribute will be inserted in the share url (i.e. https://www.facebook.com/sharer/sharer.php?u=[[URL]]).  
To keep your `href` unchanged, add `-noshare` to the network name.
