### PR TITLE
feat(mrml-cli): use stdin to read input

### DIFF
--- a/packages/mrml-cli/Cargo.toml
+++ b/packages/mrml-cli/Cargo.toml
@@ -17,5 +17,7 @@ name = "mrml"
 [dependencies]
 mrml = { path = "../mrml-core", version = "1.2.1" }
 clap = "3.0.0-beta.2"
+env_logger = "0.8.3"
+log = "0.4.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }


### PR DESCRIPTION
Signed-off-by: Jérémie Drouet <jeremie.drouet@gmail.com>

Handle input file using stdin as asked here: https://github.com/jdrouet/mrml/issues/151

Food for thoughts: maybe using `--file <filename>` or `--stdin` would be better, but this would break the CLI compatibility with previous versions.