### PR TITLE
feat(mrml-wasm): add mj-include feature

### DIFF
--- a/packages/mrml-core/src/mj_body/children.rs
+++ b/packages/mrml-core/src/mj_body/children.rs
@@ -65,7 +65,7 @@ impl MjBodyChild {
             Self::MjDivider(elt) => elt,
             Self::MjGroup(elt) => elt,
             Self::MjHero(elt) => elt,
-            Self::MjInclude(_elt) => todo!(),
+            Self::MjInclude(elt) => elt,
             Self::MjImage(elt) => elt,
             Self::MjNavbar(elt) => elt,
             Self::MjRaw(elt) => elt,

--- a/packages/mrml-core/src/prelude/parse/memory_loader.rs
+++ b/packages/mrml-core/src/prelude/parse/memory_loader.rs
@@ -1,5 +1,8 @@
 //! Module containing a loader where all the possible files are stored in memory.
 
+use std::collections::HashMap;
+use std::iter::FromIterator;
+
 use super::loader::IncludeLoaderError;
 use crate::prelude::hash::Map;
 use crate::prelude::parse::loader::IncludeLoader;
@@ -40,6 +43,12 @@ impl<K: ToString, V: ToString> From<Vec<(K, V)>> for MemoryIncludeLoader {
                 res
             });
         MemoryIncludeLoader::from(res)
+    }
+}
+
+impl From<HashMap<String, String>> for MemoryIncludeLoader {
+    fn from(value: HashMap<String, String>) -> Self {
+        MemoryIncludeLoader(Map::from_iter(value.into_iter()))
     }
 }
 

--- a/packages/mrml-wasm/examples/browser/main.test.js
+++ b/packages/mrml-wasm/examples/browser/main.test.js
@@ -23,4 +23,41 @@ describe('mrml-wasm in the browser', function () {
     expect(result.type).toBe('success');
     expect(result.content).not.toContain('Goodbye');
   });
+
+  it('should use noop include loader by default', function () {
+    const engine = new Engine();
+    engine.setRenderOptions({
+      disableComments: true,
+      fonts: {},
+    });
+    const result = engine.toHtml(`<mjml>
+<mj-body>
+  <mj-include path="./header.mjml" />
+</mj-body>
+</mjml>`);
+    expect(result.type).toBe('error');
+  });
+
+  it('should use memory include loader', function () {
+    const engine = new Engine();
+    engine.setParserOptions({
+      includeLoader: {
+        type: 'memory',
+        content: {
+          './header.mjml': '<mj-text>Hello World</mj-text>',
+        },
+      },
+    });
+    engine.setRenderOptions({
+      disableComments: true,
+      fonts: {},
+    });
+    const result = engine.toHtml(`<mjml>
+<mj-body>
+  <mj-include path="./header.mjml" />
+</mj-body>
+</mjml>`);
+    expect(result.type).toBe('success');
+    expect(result.content).toContain('Hello World');
+  });
 });

--- a/packages/mrml-wasm/examples/node/main.test.js
+++ b/packages/mrml-wasm/examples/node/main.test.js
@@ -25,4 +25,41 @@ describe('mrml-wasm in node', function () {
     assert.equal(result.type, 'success');
     assert.doesNotMatch(result.content, /Goodbye/);
   });
+
+  it('should use noop include loader by default', function () {
+    const engine = new Engine();
+    engine.setRenderOptions({
+      disableComments: true,
+      fonts: {},
+    });
+    const result = engine.toHtml(`<mjml>
+<mj-body>
+  <mj-include path="./header.mjml" />
+</mj-body>
+</mjml>`);
+    assert.equal(result.type, 'error');
+  });
+
+  it('should use memory include loader', function () {
+    const engine = new Engine();
+    engine.setParserOptions({
+      includeLoader: {
+        type: 'memory',
+        content: {
+          './header.mjml': '<mj-text>Hello World</mj-text>',
+        },
+      },
+    });
+    engine.setRenderOptions({
+      disableComments: true,
+      fonts: {},
+    });
+    const result = engine.toHtml(`<mjml>
+<mj-body>
+  <mj-include path="./header.mjml" />
+</mj-body>
+</mjml>`);
+    assert.equal(result.type, 'success');
+    assert.match(result.content, /Hello/);
+  });
 });

--- a/packages/mrml-wasm/src/parser/memory_include_loader.rs
+++ b/packages/mrml-wasm/src/parser/memory_include_loader.rs
@@ -1,0 +1,14 @@
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, tsify::Tsify)]
+#[serde(rename_all = "camelCase")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct MemoryIncludeLoaderOptions {
+    pub content: HashMap<String, String>,
+}
+
+impl MemoryIncludeLoaderOptions {
+    pub fn build(self) -> Box<dyn mrml::prelude::parse::loader::IncludeLoader> {
+        Box::new(mrml::prelude::parse::memory_loader::MemoryIncludeLoader::from(self.content))
+    }
+}

--- a/packages/mrml-wasm/src/parser/mod.rs
+++ b/packages/mrml-wasm/src/parser/mod.rs
@@ -1,0 +1,41 @@
+mod memory_include_loader;
+
+pub use memory_include_loader::*;
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, tsify::Tsify)]
+#[serde(tag = "type", rename_all = "camelCase")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum IncludeLoaderOptions {
+    Noop,
+    Memory(MemoryIncludeLoaderOptions),
+}
+
+impl Default for IncludeLoaderOptions {
+    fn default() -> Self {
+        Self::Noop
+    }
+}
+
+impl IncludeLoaderOptions {
+    pub fn build(self) -> Box<dyn mrml::prelude::parse::loader::IncludeLoader> {
+        match self {
+            Self::Noop => Box::new(mrml::prelude::parse::noop_loader::NoopIncludeLoader),
+            Self::Memory(inner) => inner.build(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, tsify::Tsify)]
+#[serde(rename_all = "camelCase")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct ParserOptions {
+    pub include_loader: IncludeLoaderOptions,
+}
+
+impl From<ParserOptions> for mrml::prelude::parse::ParserOptions {
+    fn from(value: ParserOptions) -> Self {
+        mrml::prelude::parse::ParserOptions {
+            include_loader: value.include_loader.build(),
+        }
+    }
+}

--- a/packages/mrml-wasm/src/render/mod.rs
+++ b/packages/mrml-wasm/src/render/mod.rs
@@ -1,0 +1,28 @@
+use std::{borrow::Cow, collections::HashMap};
+
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize, tsify::Tsify)]
+#[serde(rename_all = "camelCase")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+/// Rendering options
+pub struct RenderOptions {
+    /// If disabled, the comments won't be kept in the result. Disabled by default.
+    pub disable_comments: bool,
+    /// Base url of the server to fetch the social icons.
+    pub social_icon_origin: Option<String>,
+    /// Map of fonts that can be used.
+    pub fonts: HashMap<String, String>,
+}
+
+impl From<RenderOptions> for mrml::prelude::render::Options {
+    fn from(value: RenderOptions) -> Self {
+        Self {
+            disable_comments: value.disable_comments,
+            social_icon_origin: value.social_icon_origin.map(Cow::Owned),
+            fonts: value
+                .fonts
+                .into_iter()
+                .map(|(key, value)| (key, Cow::Owned(value)))
+                .collect(),
+        }
+    }
+}


### PR DESCRIPTION
Only for noop loader and memory loader for now.
For a network loader we need those loader to by async in order to be able to use Fetch that returns a promise.