### PR TITLE
fix(mrml-core): make sure we can parse <mj-font></mj-font>

### DIFF
--- a/packages/mrml-core/src/mj_font/parse.rs
+++ b/packages/mrml-core/src/mj_font/parse.rs
@@ -38,7 +38,7 @@ fn parse(cursor: &mut MrmlCursor<'_>) -> Result<MjFont, Error> {
     let attributes = parse_attributes(cursor)?;
     let ending = cursor.assert_element_end()?;
     if !ending.empty {
-        return Err(Error::InvalidFormat(ending.span.into()));
+        cursor.assert_element_close()?;
     }
 
     Ok(MjFont { attributes })

--- a/packages/mrml-core/tests/issue-356.rs
+++ b/packages/mrml-core/tests/issue-356.rs
@@ -1,0 +1,30 @@
+#![cfg(feature = "parse")]
+
+#[test]
+fn should_parse_mjfont() {
+    let template = r#"<mjml>
+    <mj-head>
+        <mj-font href="https://fonts.googleapis.com/css?family=Inter:normal&display=swap" name="Inter" />
+        <mj-font href="https://fonts.googleapis.com/css?family=Inter:bold&display=swap" name="InterBold">
+        </mj-font>
+    </mj-head>
+    <mj-body>
+        <div>Hello World</div>
+    </mj-body>
+</mjml>"#;
+    let _ = mrml::parse(template).unwrap();
+}
+
+#[test]
+fn should_parse_mjimage() {
+    let template = r#"<mjml>
+    <mj-body>
+        <div>Hello World</div>
+        <mj-image src="/other.png" />
+        <mj-image src="/wherever.png">  </mj-image>
+        <mj-image src="/wherever.png">
+        </mj-image>
+    </mj-body>
+</mjml>"#;
+    let _ = mrml::parse(template).unwrap();
+}


### PR DESCRIPTION
Fixes #356 