### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "mrml"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "async-trait",
  "concat-idents",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "mrml-python"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "mrml",
  "pyo3",

--- a/packages/mrml-core/CHANGELOG.md
+++ b/packages/mrml-core/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.2](https://github.com/jdrouet/mrml/compare/mrml-v3.0.1...mrml-v3.0.2) - 2024-02-24
+
+### Fixed
+- *(mrml-core)* add missing comment parser for mj-head ([#374](https://github.com/jdrouet/mrml/pull/374))
+
 ## [3.0.1](https://github.com/jdrouet/mrml/compare/mrml-v3.0.0...mrml-v3.0.1) - 2024-02-10
 
 ### Fixed

--- a/packages/mrml-core/Cargo.toml
+++ b/packages/mrml-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mrml"
 description = "Rust implementation of MJML renderer"
 keywords = ["email", "mjml"]
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Jérémie Drouet <jeremie.drouet@gmail.com>"]
 edition = "2018"
 license-file = "license.md"

--- a/packages/mrml-python/CHANGELOG.md
+++ b/packages/mrml-python/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/jdrouet/mrml/compare/mrml-python-v0.1.2...mrml-python-v0.1.3) - 2024-02-24
+
+### Other
+- updated the following local packages: mrml
+
 ## [0.1.2](https://github.com/jdrouet/mrml/compare/mrml-python-v0.1.1...mrml-python-v0.1.2) - 2024-02-10
 
 ### Other

--- a/packages/mrml-python/Cargo.toml
+++ b/packages/mrml-python/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mrml-python"
 description = "Python wrapping on MRML"
 keywords = ["email", "mjml"]
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Jérémie Drouet <jeremie.drouet@gmail.com>"]
 edition = "2021"
 license-file = "license.md"
@@ -16,5 +16,5 @@ name = "mrml"
 crate-type = ["cdylib"]
 
 [dependencies]
-mrml = { version = "3.0.1", path = "../mrml-core" }
+mrml = { version = "3.0.2", path = "../mrml-core" }
 pyo3 = { version = "0.20.0", features = ["extension-module"] }


### PR DESCRIPTION
## 🤖 New release
* `mrml`: 3.0.1 -> 3.0.2 (✓ API compatible changes)
* `mrml-python`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `mrml`
<blockquote>

## [3.0.2](https://github.com/jdrouet/mrml/compare/mrml-v3.0.1...mrml-v3.0.2) - 2024-02-24

### Fixed
- *(mrml-core)* add missing comment parser for mj-head ([#374](https://github.com/jdrouet/mrml/pull/374))

## `mrml-python`
<blockquote>

## [0.1.3](https://github.com/jdrouet/mrml/compare/mrml-python-v0.1.2...mrml-python-v0.1.3) - 2024-02-24

### Other
- updated the following local packages: mrml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).