### PR TITLE
fix(mrml-core): apply mj-attributes inside mj-include tags

### DIFF
--- a/packages/mrml-core/tests/mj_head_include.rs
+++ b/packages/mrml-core/tests/mj_head_include.rs
@@ -1,0 +1,27 @@
+#![cfg(feature = "parse")]
+
+#[test]
+fn should_apply_head_includes() {
+    use mrml::{
+        parse_with_options,
+        prelude::{
+            parser::{memory_loader::MemoryIncludeLoader, ParserOptions},
+            render::RenderOptions,
+        },
+    };
+
+    let include = r#"<mj-attributes>
+        <mj-all font-family="serif" />
+        <mj-class name="heading" color="red" />
+    </mj-attributes>"#;
+    let loader = MemoryIncludeLoader::from(vec![("mj-head-include-attributes.mjml", include)]);
+    let parser_opts = ParserOptions {
+        include_loader: Box::new(loader),
+    };
+
+    let render_opts = RenderOptions::default();
+    let template = include_str!("resources/mj-head-include.mjml");
+    let expected = include_str!("resources/mj-head-include.html");
+    let root = parse_with_options(template, &parser_opts).unwrap();
+    html_compare::assert_similar(expected, root.render(&render_opts).unwrap().as_str());
+}

--- a/packages/mrml-core/tests/resources/mj-head-include.html
+++ b/packages/mrml-core/tests/resources/mj-head-include.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
+  xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <title></title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style type="text/css">
+    #outlook a {
+      padding: 0;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
+
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+  </style>
+  <!--[if mso]>
+<noscript>
+<xml>
+<o:OfficeDocumentSettings>
+<o:AllowPNG/>
+<o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml>
+</noscript>
+<![endif]-->
+  <!--[if lte mso 11]>
+<style type="text/css">
+.mj-outlook-group-fix { width:100% !important; }
+</style>
+<![endif]-->
+  <style type="text/css">
+    @media only screen and (min-width:480px) {
+      .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+    }
+  </style>
+  <style media="screen and (min-width:480px)">
+    .moz-text-html .mj-column-per-100 {
+      width: 100% !important;
+      max-width: 100%;
+    }
+  </style>
+</head>
+
+<body style="word-spacing:normal;">
+  <div>
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix"
+                style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;"
+                  width="100%">
+                  <tbody>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        <div style="font-family:serif;font-size:13px;line-height:1;text-align:left;color:red;">
+                          coucou</div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+  </div>
+</body>
+
+</html>

--- a/packages/mrml-core/tests/resources/mj-head-include.mjml
+++ b/packages/mrml-core/tests/resources/mj-head-include.mjml
@@ -1,0 +1,14 @@
+<mjml>
+  <mj-head>
+    <mj-include path="mj-head-include-attributes.mjml" />
+  </mj-head>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-text mj-class="heading">
+          coucou
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>


### PR DESCRIPTION
I noticed a bug that seems to differ from the canonical MJML implementation. This PR implements one possible fix. I tried to make the change as minimally invasive as possible, but I'm open to ideas to clean this up if desired.

**Bug description:**
Any `<mj-attributes>` tags loaded inside an `<mj-include>` tag are ignored. See the additional test case in the PR changes for an example.

**Change description:**
We update `mj_head/render.rs` to scan nested attributes inside `<mj-include>` children. To reduce repeated code, I refactored the `fold()` bodies into helper functions, but they are otherwise unchanged.

I added a test case that fails on the current `main` branch.

Let me know what you think!