### PR TITLE
feat(mrml-python): add a Python types stub file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,6 +1645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,15 +1673,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89dc7a5850d0e983be1ec2a463a171d20990487c3cfcd68b5363f1ee3d6fe0"
+checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
  "parking_lot",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -1684,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07426f0d8fe5a601f26293f300afd1a7b1ed5e78b2a705870c5f30893c5163be"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1694,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb7dec17e17766b46bca4f1a4215a85006b4c2ecde122076c562dd058da6cf1"
+checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1704,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f738b4e40d50b5711957f142878cfa0f28e054aa0ebdfc3fd137a843f74ed3"
+checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1716,12 +1723,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc910d4851847827daf9d6cdd4a823fbdaab5b8818325c5e97a86da79e8881f"
+checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
 dependencies = [
  "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn 2.0.48",
 ]

--- a/packages/mrml-python/Cargo.toml
+++ b/packages/mrml-python/Cargo.toml
@@ -20,4 +20,4 @@ mrml = { version = "3.1.5", path = "../mrml-core", features = [
   "http-loader-ureq",
   "local-loader",
 ] }
-pyo3 = { version = "0.20.0", features = ["extension-module"] }
+pyo3 = { version = "0.21.2", features = ["extension-module"] }

--- a/packages/mrml-python/mrml.pyi
+++ b/packages/mrml-python/mrml.pyi
@@ -1,0 +1,80 @@
+from typing import Any, Dict, Optional, Set, Union
+
+class NoopIncludeLoaderOptions:
+    """No-operation loader options class, which requires no specific configuration."""
+
+    pass
+
+class MemoryIncludeLoaderOptions:
+    """MemoryIncludeLoaderOptions stores mappings for in-memory data using a dictionary."""
+    def __init__(self, data: Dict[str, str]) -> None: ...
+
+class LocalIncludeLoaderOptions:
+    """LocalIncludeLoaderOptions configures a loader with a filesystem path."""
+    def __init__(self, path: str) -> None: ...
+
+class HttpIncludeLoaderOptionsMode:
+    """HttpIncludeLoaderOptionsMode is an enumeration for HTTP loader behavior modes."""
+
+    Allow: "HttpIncludeLoaderOptionsMode"
+    Deny: "HttpIncludeLoaderOptionsMode"
+
+class HttpIncludeLoaderOptions:
+    """HttpIncludeLoaderOptions defines options for an HTTP include loader, including mode and a list of URLs."""
+    def __init__(self, mode: HttpIncludeLoaderOptionsMode, list: Set[str]) -> None: ...
+
+class ParserIncludeLoaderOptions:
+    """ParserIncludeLoaderOptions is a union type that can represent any type of include loader options."""
+    def __init__(
+        self,
+        loader: Union[
+            NoopIncludeLoaderOptions,
+            MemoryIncludeLoaderOptions,
+            LocalIncludeLoaderOptions,
+            HttpIncludeLoaderOptions,
+        ],
+    ) -> None: ...
+    def build(self) -> Any:
+        """Build method constructs the actual loader object, might return different types based on the loader configuration."""
+        ...
+
+def noop_loader() -> ParserIncludeLoaderOptions:
+    """Factory function to create a no-operation loader."""
+    ...
+
+def memory_loader(data: Optional[Dict[str, str]] = None) -> ParserIncludeLoaderOptions:
+    """Factory function to create a memory loader with optional data."""
+    ...
+
+def local_loader(data: Optional[str] = None) -> ParserIncludeLoaderOptions:
+    """Factory function to create a local loader, converting a string path to a Path object internally."""
+    ...
+
+def http_loader(
+    mode: Optional[HttpIncludeLoaderOptionsMode] = None, list: Optional[Set[str]] = None
+) -> ParserIncludeLoaderOptions:
+    """Factory function to create an HTTP loader with optional mode and list of URLs."""
+    ...
+
+class ParserOptions:
+    """ParserOptions configures parser behavior, primarily by specifying the include loader to use."""
+    def __init__(
+        self, include_loader: Optional[ParserIncludeLoaderOptions] = None
+    ) -> None: ...
+
+class RenderOptions:
+    """RenderOptions configures rendering behavior, including whether to disable comments and how to handle social icons and fonts."""
+    def __init__(
+        self,
+        disable_comments: bool = False,
+        social_icon_origin: Optional[str] = None,
+        fonts: Optional[Dict[str, str]] = None,
+    ) -> None: ...
+
+def to_html(
+    input: str,
+    parser_options: Optional[ParserOptions] = None,
+    render_options: Optional[RenderOptions] = None,
+) -> str:
+    """Function to convert input a MJML string to HTML using optional parser and render configurations."""
+    ...

--- a/packages/mrml-python/src/lib.rs
+++ b/packages/mrml-python/src/lib.rs
@@ -214,7 +214,7 @@ fn to_html(
 
 #[pymodule]
 #[pyo3(name = "mrml")]
-fn register(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn register(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<NoopIncludeLoaderOptions>()?;
     m.add_class::<MemoryIncludeLoaderOptions>()?;
     m.add_class::<LocalIncludeLoaderOptions>()?;


### PR DESCRIPTION
Fix for #412

- Add a types stub file for the Python package
- Update and migrate to Py03 0.21.2

All the test files now lint correctly with Pylance in VSCode. 🎉