### PR TITLE
feat(mrml-core): allow to have comments at root level

### DIFF
--- a/packages/mrml-core/src/lib.rs
+++ b/packages/mrml-core/src/lib.rs
@@ -160,8 +160,10 @@ pub mod mj_wrapper;
 pub mod mjml;
 pub mod node;
 pub mod prelude;
-pub mod root;
 pub mod text;
+
+// Only used to ignore the comments at the root level
+mod root;
 
 mod helper;
 mod macros;

--- a/packages/mrml-core/src/lib.rs
+++ b/packages/mrml-core/src/lib.rs
@@ -160,6 +160,7 @@ pub mod mj_wrapper;
 pub mod mjml;
 pub mod node;
 pub mod prelude;
+pub mod root;
 pub mod text;
 
 mod helper;
@@ -191,9 +192,8 @@ pub fn parse_with_options<T: AsRef<str>>(
     input: T,
     opts: &crate::prelude::parser::ParserOptions,
 ) -> Result<mjml::Mjml, prelude::parser::Error> {
-    let parser = crate::prelude::parser::MrmlParser::new(opts);
-    let mut cursor = crate::prelude::parser::MrmlCursor::new(input.as_ref());
-    parser.parse_root(&mut cursor)
+    let root = crate::root::Root::parse_with_options(input, opts)?;
+    root.into_mjml().ok_or(prelude::parser::Error::NoRootNode)
 }
 
 #[cfg(all(feature = "parse", feature = "async"))]
@@ -224,9 +224,8 @@ pub async fn async_parse_with_options<T: AsRef<str>>(
     input: T,
     opts: std::sync::Arc<crate::prelude::parser::AsyncParserOptions>,
 ) -> Result<mjml::Mjml, prelude::parser::Error> {
-    let parser = crate::prelude::parser::AsyncMrmlParser::new(opts);
-    let mut cursor = crate::prelude::parser::MrmlCursor::new(input.as_ref());
-    parser.parse_root(&mut cursor).await
+    let root = crate::root::Root::async_parse_with_options(input, opts).await?;
+    root.into_mjml().ok_or(prelude::parser::Error::NoRootNode)
 }
 
 #[cfg(feature = "parse")]
@@ -241,9 +240,7 @@ pub async fn async_parse_with_options<T: AsRef<str>>(
 /// ```
 pub fn parse<T: AsRef<str>>(input: T) -> Result<mjml::Mjml, prelude::parser::Error> {
     let opts = crate::prelude::parser::ParserOptions::default();
-    let parser = crate::prelude::parser::MrmlParser::new(&opts);
-    let mut cursor = crate::prelude::parser::MrmlCursor::new(input.as_ref());
-    parser.parse_root(&mut cursor)
+    parse_with_options(input, &opts)
 }
 
 #[cfg(all(feature = "parse", feature = "async"))]
@@ -259,9 +256,8 @@ pub fn parse<T: AsRef<str>>(input: T) -> Result<mjml::Mjml, prelude::parser::Err
 /// # })
 /// ```
 pub async fn async_parse<T: AsRef<str>>(input: T) -> Result<mjml::Mjml, prelude::parser::Error> {
-    let parser = crate::prelude::parser::AsyncMrmlParser::default();
-    let mut cursor = crate::prelude::parser::MrmlCursor::new(input.as_ref());
-    parser.parse_root(&mut cursor).await
+    let opts = std::sync::Arc::new(crate::prelude::parser::AsyncParserOptions::default());
+    async_parse_with_options(input, opts).await
 }
 
 #[cfg(all(test, feature = "parse"))]

--- a/packages/mrml-core/src/root/mod.rs
+++ b/packages/mrml-core/src/root/mod.rs
@@ -3,6 +3,8 @@ use crate::mjml::Mjml;
 
 #[cfg(feature = "parse")]
 pub mod parse;
+#[cfg(feature = "render")]
+pub mod render;
 
 #[derive(Debug)]
 /// Representation of the `mjml` and its attributes and children defined

--- a/packages/mrml-core/src/root/mod.rs
+++ b/packages/mrml-core/src/root/mod.rs
@@ -2,18 +2,18 @@ use crate::comment::Comment;
 use crate::mjml::Mjml;
 
 #[cfg(feature = "parse")]
-pub mod parse;
+mod parse;
 #[cfg(feature = "render")]
-pub mod render;
+mod render;
 
 #[derive(Debug)]
-pub enum RootChild {
+enum RootChild {
     Mjml(Mjml),
     Comment(Comment),
 }
 
 #[derive(Debug)]
-pub struct Root(Vec<RootChild>);
+pub(crate) struct Root(Vec<RootChild>);
 
 impl AsRef<[RootChild]> for Root {
     fn as_ref(&self) -> &[RootChild] {
@@ -22,14 +22,7 @@ impl AsRef<[RootChild]> for Root {
 }
 
 impl Root {
-    pub fn as_mjml(&self) -> Option<&Mjml> {
-        self.0.iter().find_map(|item| match item {
-            RootChild::Mjml(inner) => Some(inner),
-            _ => None,
-        })
-    }
-
-    pub fn into_mjml(self) -> Option<Mjml> {
+    pub(crate) fn into_mjml(self) -> Option<Mjml> {
         self.0.into_iter().find_map(|item| match item {
             RootChild::Mjml(inner) => Some(inner),
             _ => None,

--- a/packages/mrml-core/src/root/mod.rs
+++ b/packages/mrml-core/src/root/mod.rs
@@ -7,8 +7,6 @@ pub mod parse;
 pub mod render;
 
 #[derive(Debug)]
-/// Representation of the `mjml` and its attributes and children defined
-/// in the [mjml documentation](https://documentation.mjml.io/#mjml).
 pub enum RootChild {
     Mjml(Mjml),
     Comment(Comment),

--- a/packages/mrml-core/src/root/mod.rs
+++ b/packages/mrml-core/src/root/mod.rs
@@ -1,0 +1,38 @@
+use crate::comment::Comment;
+use crate::mjml::Mjml;
+
+#[cfg(feature = "parse")]
+pub mod parse;
+
+#[derive(Debug)]
+/// Representation of the `mjml` and its attributes and children defined
+/// in the [mjml documentation](https://documentation.mjml.io/#mjml).
+pub enum RootChild {
+    Mjml(Mjml),
+    Comment(Comment),
+}
+
+#[derive(Debug)]
+pub struct Root(Vec<RootChild>);
+
+impl AsRef<[RootChild]> for Root {
+    fn as_ref(&self) -> &[RootChild] {
+        self.0.as_ref()
+    }
+}
+
+impl Root {
+    pub fn as_mjml(&self) -> Option<&Mjml> {
+        self.0.iter().find_map(|item| match item {
+            RootChild::Mjml(inner) => Some(inner),
+            _ => None,
+        })
+    }
+
+    pub fn into_mjml(self) -> Option<Mjml> {
+        self.0.into_iter().find_map(|item| match item {
+            RootChild::Mjml(inner) => Some(inner),
+            _ => None,
+        })
+    }
+}

--- a/packages/mrml-core/src/root/parse.rs
+++ b/packages/mrml-core/src/root/parse.rs
@@ -81,7 +81,7 @@ impl super::Root {
     ///     Err(err) => eprintln!("Something went wrong: {err:?}"),
     /// }
     /// ```
-    pub fn parse_with_options<T: AsRef<str>>(
+    pub(crate) fn parse_with_options<T: AsRef<str>>(
         value: T,
         opts: &ParserOptions,
     ) -> Result<Self, Error> {
@@ -91,7 +91,7 @@ impl super::Root {
     }
 
     #[cfg(feature = "async")]
-    pub async fn async_parse_with_options<T: AsRef<str>>(
+    pub(crate) async fn async_parse_with_options<T: AsRef<str>>(
         value: T,
         opts: std::sync::Arc<crate::prelude::parser::AsyncParserOptions>,
     ) -> Result<Self, Error> {
@@ -99,27 +99,6 @@ impl super::Root {
         use crate::prelude::parser::AsyncParseChildren;
 
         let parser = AsyncMrmlParser::new(opts);
-        let mut cursor = MrmlCursor::new(value.as_ref());
-        Ok(Self(parser.async_parse_children(&mut cursor).await?))
-    }
-
-    /// Function to parse a raw mjml template using the default parsing
-    /// [options](crate::prelude::parser::ParserOptions).
-    pub fn parse<T: AsRef<str>>(value: T) -> Result<Self, Error> {
-        let opts = ParserOptions::default();
-        let parser = MrmlParser::new(&opts);
-        let mut cursor = MrmlCursor::new(value.as_ref());
-        Ok(Self(parser.parse_children(&mut cursor)?))
-    }
-
-    #[cfg(feature = "async")]
-    /// Function to parse a raw mjml template using the default parsing
-    /// [options](crate::prelude::parser::ParserOptions).
-    pub async fn async_parse<T: AsRef<str>>(value: T) -> Result<Self, Error> {
-        use crate::prelude::parser::AsyncMrmlParser;
-        use crate::prelude::parser::AsyncParseChildren;
-
-        let parser = AsyncMrmlParser::default();
         let mut cursor = MrmlCursor::new(value.as_ref());
         Ok(Self(parser.async_parse_children(&mut cursor).await?))
     }

--- a/packages/mrml-core/src/root/parse.rs
+++ b/packages/mrml-core/src/root/parse.rs
@@ -1,0 +1,126 @@
+use crate::{
+    comment::Comment,
+    prelude::parser::{Error, MrmlCursor, MrmlParser, MrmlToken, ParseChildren, ParserOptions},
+};
+
+use super::RootChild;
+
+impl<'opts> crate::prelude::parser::ParseChildren<Vec<RootChild>> for MrmlParser<'opts> {
+    fn parse_children(&self, cursor: &mut MrmlCursor<'_>) -> Result<Vec<RootChild>, Error> {
+        use crate::prelude::parser::ParseElement;
+
+        let mut result = Vec::new();
+        while let Some(token) = cursor.next_token() {
+            match token? {
+                MrmlToken::Comment(inner) => {
+                    result.push(RootChild::Comment(Comment::from(inner.text.as_str())));
+                }
+                MrmlToken::ElementStart(inner) if inner.local.eq("mjml") => {
+                    result.push(RootChild::Mjml(self.parse(cursor, inner.local)?));
+                }
+                other => {
+                    return Err(Error::UnexpectedToken(other.span()));
+                }
+            }
+        }
+        Ok(result)
+    }
+}
+
+#[cfg(feature = "async")]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl crate::prelude::parser::AsyncParseChildren<Vec<RootChild>>
+    for crate::prelude::parser::AsyncMrmlParser
+{
+    async fn async_parse_children<'a>(
+        &self,
+        cursor: &mut MrmlCursor<'a>,
+    ) -> Result<Vec<RootChild>, Error> {
+        use crate::prelude::parser::AsyncParseElement;
+
+        let mut result = Vec::new();
+        while let Some(token) = cursor.next_token() {
+            match token? {
+                MrmlToken::Comment(inner) => {
+                    result.push(RootChild::Comment(Comment::from(inner.text.as_str())));
+                }
+                MrmlToken::ElementStart(inner) if inner.local.eq("mjml") => {
+                    let element = self.async_parse(cursor, inner.local).await?;
+                    result.push(RootChild::Mjml(element));
+                }
+                other => {
+                    return Err(Error::UnexpectedToken(other.span()));
+                }
+            }
+        }
+        Ok(result)
+    }
+}
+
+impl super::Root {
+    /// Function to parse a raw mjml template with some parsing
+    /// [options](crate::prelude::parser::ParserOptions).
+    ///
+    /// You can specify the kind of loader mrml needs to use for loading the
+    /// content of [`mj-include`](crate::mj_include) elements.
+    ///
+    /// You can take a look at the available loaders
+    /// [here](crate::prelude::parser).
+    ///
+    /// ```rust
+    /// use mrml::root::Root;
+    /// use mrml::prelude::parser::ParserOptions;
+    /// use mrml::prelude::parser::memory_loader::MemoryIncludeLoader;
+    ///
+    /// let options = ParserOptions {
+    ///     include_loader: Box::new(MemoryIncludeLoader::default()),
+    /// };
+    /// match Root::parse_with_options("<mjml><mj-head /><mj-body /></mjml>", &options) {
+    ///     Ok(_) => println!("Success!"),
+    ///     Err(err) => eprintln!("Something went wrong: {err:?}"),
+    /// }
+    /// ```
+    pub fn parse_with_options<T: AsRef<str>>(
+        value: T,
+        opts: &ParserOptions,
+    ) -> Result<Self, Error> {
+        let parser = MrmlParser::new(opts);
+        let mut cursor = MrmlCursor::new(value.as_ref());
+        Ok(Self(parser.parse_children(&mut cursor)?))
+    }
+
+    #[cfg(feature = "async")]
+    pub async fn async_parse_with_options<T: AsRef<str>>(
+        value: T,
+        opts: std::sync::Arc<crate::prelude::parser::AsyncParserOptions>,
+    ) -> Result<Self, Error> {
+        use crate::prelude::parser::AsyncMrmlParser;
+        use crate::prelude::parser::AsyncParseChildren;
+
+        let parser = AsyncMrmlParser::new(opts);
+        let mut cursor = MrmlCursor::new(value.as_ref());
+        Ok(Self(parser.async_parse_children(&mut cursor).await?))
+    }
+
+    /// Function to parse a raw mjml template using the default parsing
+    /// [options](crate::prelude::parser::ParserOptions).
+    pub fn parse<T: AsRef<str>>(value: T) -> Result<Self, Error> {
+        let opts = ParserOptions::default();
+        let parser = MrmlParser::new(&opts);
+        let mut cursor = MrmlCursor::new(value.as_ref());
+        Ok(Self(parser.parse_children(&mut cursor)?))
+    }
+
+    #[cfg(feature = "async")]
+    /// Function to parse a raw mjml template using the default parsing
+    /// [options](crate::prelude::parser::ParserOptions).
+    pub async fn async_parse<T: AsRef<str>>(value: T) -> Result<Self, Error> {
+        use crate::prelude::parser::AsyncMrmlParser;
+        use crate::prelude::parser::AsyncParseChildren;
+
+        let parser = AsyncMrmlParser::default();
+        let mut cursor = MrmlCursor::new(value.as_ref());
+        Ok(Self(parser.async_parse_children(&mut cursor).await?))
+    }
+}

--- a/packages/mrml-core/src/root/render.rs
+++ b/packages/mrml-core/src/root/render.rs
@@ -1,0 +1,40 @@
+use std::cell::{Ref, RefCell};
+use std::rc::Rc;
+
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+
+pub struct RootRender<'e, 'h> {
+    header: Rc<RefCell<Header<'h>>>,
+    element: &'e super::Root,
+}
+
+impl<'e, 'h> Render<'h> for RootRender<'e, 'h> {
+    fn header(&self) -> Ref<Header<'h>> {
+        self.header.borrow()
+    }
+
+    fn render(&self, opts: &RenderOptions) -> Result<String, Error> {
+        let mut result = String::new();
+        for element in self.element.as_ref().iter() {
+            let content = match element {
+                super::RootChild::Comment(inner) => {
+                    inner.renderer(self.header.clone()).render(opts)?
+                }
+                super::RootChild::Mjml(inner) => {
+                    inner.renderer(self.header.clone()).render(opts)?
+                }
+            };
+            result.push_str(&content);
+        }
+        Ok(result)
+    }
+}
+
+impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for super::Root {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+        Box::new(RootRender::<'e, 'h> {
+            element: self,
+            header,
+        })
+    }
+}

--- a/packages/mrml-core/src/root/render.rs
+++ b/packages/mrml-core/src/root/render.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
-pub struct RootRender<'e, 'h> {
+pub(crate) struct RootRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,
     element: &'e super::Root,
 }

--- a/packages/mrml-core/tests/issue-409.rs
+++ b/packages/mrml-core/tests/issue-409.rs
@@ -1,0 +1,7 @@
+#![cfg(feature = "parse")]
+
+#[test]
+fn should_parse_and_ignore_root_comment() {
+    let template = r#"<!-- ignore me --><mjml><mj-body></mj-body></mjml>"#;
+    let _ = mrml::parse(template).unwrap();
+}


### PR DESCRIPTION
As noted by #409, we currently cannot have a comment at the root of the template like following

```
<!-- not allowed -->
<mjml>
<mj-body>
<!-- allowed -->
</mj-body>
</mjml>
```

To fix that, I introduced a `Root` element which will be called when doing `mrml::parse` or `mrml::async_parse` and will only return the contained `Mjml` component. This means that the comment will be just ignored.