### PR TITLE
refactor(mrml-core): simplify codebase and improve performance

### DIFF
--- a/packages/mrml-core/lib/html-compare/src/lib.rs
+++ b/packages/mrml-core/lib/html-compare/src/lib.rs
@@ -418,7 +418,7 @@ pub fn compare<'a>(expected: &'a str, generated: &'a str) -> Result<(), Error<'a
 
 pub fn assert_similar(expected: &str, generated: &str) {
     if let Err(error) = compare(expected, generated) {
-        panic!("{error}");
+        panic!("{error}\n\n## EXPECTED\n\n{expected}\n\n## GENERATED\n\n{generated}");
     }
 }
 

--- a/packages/mrml-core/lib/html-compare/src/lib.rs
+++ b/packages/mrml-core/lib/html-compare/src/lib.rs
@@ -418,7 +418,7 @@ pub fn compare<'a>(expected: &'a str, generated: &'a str) -> Result<(), Error<'a
 
 pub fn assert_similar(expected: &str, generated: &str) {
     if let Err(error) = compare(expected, generated) {
-        panic!("{error}\n\n## EXPECTED\n\n{expected}\n\n## GENERATED\n\n{generated}");
+        panic!("{error}");
     }
 }
 

--- a/packages/mrml-core/src/comment/render.rs
+++ b/packages/mrml-core/src/comment/render.rs
@@ -2,22 +2,17 @@ use super::Comment;
 use crate::prelude::render::*;
 
 struct CommentRender<'e, 'h> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e Comment,
 }
 
 impl<'e, 'h> Render<'e, 'h> for CommentRender<'e, 'h> {
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        self.context
     }
 
-    fn render(
-        &self,
-        opts: &RenderOptions,
-        _header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
-        if !opts.disable_comments {
+    fn render(&self, _header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+        if !self.context.options.disable_comments {
             buf.push_str("<!--");
             buf.push_str(self.element.children.as_str());
             buf.push_str("-->");
@@ -31,10 +26,10 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for Comment {
         true
     }
 
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(CommentRender::<'e, 'h> {
             element: self,
-            header,
+            context,
         })
     }
 }

--- a/packages/mrml-core/src/comment/render.rs
+++ b/packages/mrml-core/src/comment/render.rs
@@ -1,20 +1,22 @@
-use std::cell::{Ref, RefCell};
-use std::rc::Rc;
-
 use super::Comment;
-use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable};
+use crate::prelude::render::*;
 
 struct CommentRender<'e, 'h> {
-    header: Rc<RefCell<Header<'h>>>,
+    header: &'h Header<'h>,
     element: &'e Comment,
 }
 
 impl<'e, 'h> Render<'e, 'h> for CommentRender<'e, 'h> {
-    fn header(&self) -> Ref<Header<'h>> {
-        self.header.borrow()
+    fn header(&self) -> &'h Header<'h> {
+        self.header
     }
 
-    fn render(&self, opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(
+        &self,
+        opts: &RenderOptions,
+        _header: &mut VariableHeader,
+        buf: &mut RenderBuffer,
+    ) -> Result<(), Error> {
         if !opts.disable_comments {
             buf.push_str("<!--");
             buf.push_str(self.element.children.as_str());
@@ -29,7 +31,7 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for Comment {
         true
     }
 
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(CommentRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/comment/render.rs
+++ b/packages/mrml-core/src/comment/render.rs
@@ -2,7 +2,7 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::Comment;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable};
 
 struct CommentRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,
@@ -14,12 +14,13 @@ impl<'e, 'h> Render<'e, 'h> for CommentRender<'e, 'h> {
         self.header.borrow()
     }
 
-    fn render(&self, opts: &RenderOptions) -> Result<String, Error> {
-        if opts.disable_comments {
-            Ok(String::default())
-        } else {
-            Ok(String::from("<!--") + &self.element.children + "-->")
+    fn render(&self, opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
+        if !opts.disable_comments {
+            buf.push_str("<!--");
+            buf.push_str(self.element.children.as_str());
+            buf.push_str("-->");
         }
+        Ok(())
     }
 }
 

--- a/packages/mrml-core/src/comment/render.rs
+++ b/packages/mrml-core/src/comment/render.rs
@@ -11,11 +11,11 @@ impl<'e, 'h> Render<'e, 'h> for CommentRender<'e, 'h> {
         self.context
     }
 
-    fn render(&self, _header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         if !self.context.options.disable_comments {
-            buf.push_str("<!--");
-            buf.push_str(self.element.children.as_str());
-            buf.push_str("-->");
+            cursor.buffer.push_str("<!--");
+            cursor.buffer.push_str(self.element.children.as_str());
+            cursor.buffer.push_str("-->");
         }
         Ok(())
     }

--- a/packages/mrml-core/src/comment/render.rs
+++ b/packages/mrml-core/src/comment/render.rs
@@ -1,8 +1,8 @@
 use super::Comment;
 use crate::prelude::render::*;
 
-impl<'e, 'h> Render<'e, 'h> for Renderer<'e, 'h, Comment, ()> {
-    fn context(&self) -> &'h RenderContext<'h> {
+impl<'root> Render<'root> for Renderer<'root, Comment, ()> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -16,12 +16,15 @@ impl<'e, 'h> Render<'e, 'h> for Renderer<'e, 'h, Comment, ()> {
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for Comment {
-    fn is_raw(&'e self) -> bool {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for Comment {
+    fn is_raw(&self) -> bool {
         true
     }
 
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/comment/render.rs
+++ b/packages/mrml-core/src/comment/render.rs
@@ -1,12 +1,7 @@
 use super::Comment;
 use crate::prelude::render::*;
 
-struct CommentRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e Comment,
-}
-
-impl<'e, 'h> Render<'e, 'h> for CommentRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for Renderer<'e, 'h, Comment, ()> {
     fn context(&self) -> &'h RenderContext<'h> {
         self.context
     }
@@ -27,10 +22,7 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for Comment {
     }
 
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(CommentRender::<'e, 'h> {
-            element: self,
-            context,
-        })
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/comment/render.rs
+++ b/packages/mrml-core/src/comment/render.rs
@@ -9,7 +9,7 @@ struct CommentRender<'e, 'h> {
     element: &'e Comment,
 }
 
-impl<'e, 'h> Render<'h> for CommentRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for CommentRender<'e, 'h> {
     fn header(&self) -> Ref<Header<'h>> {
         self.header.borrow()
     }
@@ -28,7 +28,7 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for Comment {
         true
     }
 
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(CommentRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/helper/condition.rs
+++ b/packages/mrml-core/src/helper/condition.rs
@@ -4,19 +4,3 @@ pub const END_CONDITIONAL_TAG: &str = "<![endif]-->";
 pub const START_NEGATION_CONDITIONAL_TAG: &str = "<!--[if !mso | IE]><!-->";
 pub const START_MSO_NEGATION_CONDITIONAL_TAG: &str = "<!--[if !mso]><!-->";
 pub const END_NEGATION_CONDITIONAL_TAG: &str = "<!--<![endif]-->";
-
-pub fn conditional_tag<T: AsRef<str>>(input: T) -> String {
-    START_CONDITIONAL_TAG.to_string() + input.as_ref() + END_CONDITIONAL_TAG
-}
-
-pub fn negation_conditional_tag<T: AsRef<str>>(input: T) -> String {
-    START_NEGATION_CONDITIONAL_TAG.to_string() + input.as_ref() + END_NEGATION_CONDITIONAL_TAG
-}
-
-pub fn mso_conditional_tag<T: AsRef<str>>(input: T) -> String {
-    START_MSO_CONDITIONAL_TAG.to_string() + input.as_ref() + END_CONDITIONAL_TAG
-}
-
-pub fn mso_negation_conditional_tag<T: AsRef<str>>(input: T) -> String {
-    START_MSO_NEGATION_CONDITIONAL_TAG.to_string() + input.as_ref() + END_NEGATION_CONDITIONAL_TAG
-}

--- a/packages/mrml-core/src/helper/condition.rs
+++ b/packages/mrml-core/src/helper/condition.rs
@@ -1,6 +1,0 @@
-pub const START_CONDITIONAL_TAG: &str = "<!--[if mso | IE]>";
-pub const START_MSO_CONDITIONAL_TAG: &str = "<!--[if mso]>";
-pub const END_CONDITIONAL_TAG: &str = "<![endif]-->";
-pub const START_NEGATION_CONDITIONAL_TAG: &str = "<!--[if !mso | IE]><!-->";
-pub const START_MSO_NEGATION_CONDITIONAL_TAG: &str = "<!--[if !mso]><!-->";
-pub const END_NEGATION_CONDITIONAL_TAG: &str = "<!--<![endif]-->";

--- a/packages/mrml-core/src/helper/mod.rs
+++ b/packages/mrml-core/src/helper/mod.rs
@@ -1,6 +1,4 @@
 #[cfg(feature = "render")]
-pub mod condition;
-#[cfg(feature = "render")]
 pub mod size;
 #[cfg(any(feature = "render", feature = "print"))]
 pub mod sort;

--- a/packages/mrml-core/src/helper/mod.rs
+++ b/packages/mrml-core/src/helper/mod.rs
@@ -8,5 +8,3 @@ pub mod sort;
 pub mod spacing;
 #[cfg(feature = "render")]
 pub mod style;
-#[cfg(feature = "render")]
-pub mod tag;

--- a/packages/mrml-core/src/helper/style.rs
+++ b/packages/mrml-core/src/helper/style.rs
@@ -1,26 +1,20 @@
+use std::borrow::Cow;
+
 #[derive(Default)]
 pub struct Style {
-    selectors: Vec<String>,
-    content: Vec<String>,
+    selectors: Vec<Cow<'static, str>>,
+    content: Vec<Cow<'static, str>>,
 }
 
 impl Style {
-    pub fn add_content(mut self, value: String) -> Self {
-        self.content.push(value);
+    pub fn add_content<V: Into<Cow<'static, str>>>(mut self, value: V) -> Self {
+        self.content.push(value.into());
         self
     }
 
-    pub fn add_str_content(self, value: &str) -> Self {
-        self.add_content(value.to_string())
-    }
-
-    pub fn add_selector(mut self, name: String) -> Self {
-        self.selectors.push(name);
+    pub fn add_selector<V: Into<Cow<'static, str>>>(mut self, name: V) -> Self {
+        self.selectors.push(name.into());
         self
-    }
-
-    pub fn add_str_selector(self, name: &str) -> Self {
-        self.add_selector(name.to_string())
     }
 }
 
@@ -39,10 +33,10 @@ mod tests {
     #[test]
     fn basic() {
         let result = Style::default()
-            .add_selector("body".into())
-            .add_str_selector("main")
-            .add_content("background: red;".into())
-            .add_str_content("color: blue;")
+            .add_selector("body".to_string())
+            .add_selector("main")
+            .add_content("background: red;".to_string())
+            .add_content("color: blue;")
             .to_string();
         let expected = "body,\nmain { background: red;\ncolor: blue; }";
         assert_eq!(result, expected);

--- a/packages/mrml-core/src/mj_accordion/render.rs
+++ b/packages/mrml-core/src/mj_accordion/render.rs
@@ -54,7 +54,7 @@ impl<'e, 'h> MjAccordionRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjAccordionRender<'e, 'h> {
-    fn default_attribute(&self, name: &str) -> Option<&str> {
+    fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "border" => Some("2px solid black"),
             "font-family" => Some("Ubuntu, Helvetica, Arial, sans-serif"),

--- a/packages/mrml-core/src/mj_accordion/render.rs
+++ b/packages/mrml-core/src/mj_accordion/render.rs
@@ -106,7 +106,7 @@ impl<'root> Render<'root> for Renderer<'root, MjAccordion, ()> {
         for child in self.element.children.iter() {
             let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|key| {
-                renderer.maybe_add_extra_attribute(key, self.attribute(key).map(|v| v.to_owned()));
+                renderer.maybe_add_extra_attribute(key, self.attribute(key));
             });
             renderer.render(cursor)?;
         }

--- a/packages/mrml-core/src/mj_accordion/render.rs
+++ b/packages/mrml-core/src/mj_accordion/render.rs
@@ -31,7 +31,7 @@ const STYLE: &str = r#"noinput.mj-accordion-checkbox { display: block! important
 @goodbye { @gmail }
 "#;
 
-impl<'element, 'header> Renderer<'element, 'header, MjAccordion, ()> {
+impl<'root> Renderer<'root, MjAccordion, ()> {
     fn update_header(&self, header: &mut VariableHeader) {
         let font_families = self.attribute("font-family");
         header.maybe_add_font_families(font_families);
@@ -39,7 +39,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjAccordion, ()> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjAccordion, ()> {
+impl<'root> Render<'root> for Renderer<'root, MjAccordion, ()> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "border" => Some("2px solid black"),
@@ -57,7 +57,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -65,7 +65,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         Some(NAME)
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -116,20 +116,20 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjAccordion {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjAccordion {
     fn renderer(
-        &'element self,
-        context: &'header RenderContext<'header>,
-    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }
 
-impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjAccordionChild {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjAccordionChild {
     fn renderer(
-        &'element self,
-        context: &'header RenderContext<'header>,
-    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         match self {
             Self::MjAccordionElement(elt) => elt.renderer(context),
             Self::Comment(elt) => elt.renderer(context),

--- a/packages/mrml-core/src/mj_accordion/render.rs
+++ b/packages/mrml-core/src/mj_accordion/render.rs
@@ -15,7 +15,7 @@ const CHILDREN_ATTRIBUTES: [&str; 9] = [
 ];
 
 struct MjAccordionRender<'e, 'h> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e MjAccordion,
     container_width: Option<Pixel>,
     siblings: usize,
@@ -73,8 +73,8 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionRender<'e, 'h> {
         Some(NAME)
     }
 
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        self.context
     }
 
     fn get_width(&self) -> Option<Size> {
@@ -95,12 +95,7 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionRender<'e, 'h> {
         self.raw_siblings = value;
     }
 
-    fn render(
-        &self,
-        opts: &RenderOptions,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
         self.update_header(header);
 
         let tbody = Tag::tbody();
@@ -117,11 +112,11 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionRender<'e, 'h> {
         table.render_open(buf);
         tbody.render_open(buf);
         for child in self.element.children.iter() {
-            let mut renderer = child.renderer(self.header);
+            let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|key| {
                 renderer.maybe_add_extra_attribute(key, self.attribute(key));
             });
-            renderer.render(opts, header, buf)?;
+            renderer.render(header, buf)?;
         }
         tbody.render_close(buf);
         table.render_close(buf);
@@ -130,10 +125,10 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordion {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjAccordionRender::<'e, 'h> {
             element: self,
-            header,
+            context,
             container_width: None,
             siblings: 1,
             raw_siblings: 0,
@@ -142,10 +137,10 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordion {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordionChild {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         match self {
-            Self::MjAccordionElement(elt) => elt.renderer(header),
-            Self::Comment(elt) => elt.renderer(header),
+            Self::MjAccordionElement(elt) => elt.renderer(context),
+            Self::Comment(elt) => elt.renderer(context),
         }
     }
 }

--- a/packages/mrml-core/src/mj_accordion/render.rs
+++ b/packages/mrml-core/src/mj_accordion/render.rs
@@ -3,8 +3,7 @@ use std::rc::Rc;
 
 use super::{MjAccordion, MjAccordionChild, NAME};
 use crate::helper::size::{Pixel, Size};
-use crate::helper::tag::Tag;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 const CHILDREN_ATTRIBUTES: [&str; 9] = [
     "border",

--- a/packages/mrml-core/src/mj_accordion/render.rs
+++ b/packages/mrml-core/src/mj_accordion/render.rs
@@ -95,8 +95,8 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionRender<'e, 'h> {
         self.raw_siblings = value;
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
-        self.update_header(header);
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
+        self.update_header(&mut cursor.header);
 
         let tbody = Tag::tbody();
         let table = Tag::table()
@@ -109,17 +109,17 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionRender<'e, 'h> {
             .add_attribute("cellpadding", "0")
             .add_class("mj-accordion");
 
-        table.render_open(buf);
-        tbody.render_open(buf);
+        table.render_open(&mut cursor.buffer);
+        tbody.render_open(&mut cursor.buffer);
         for child in self.element.children.iter() {
             let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|key| {
                 renderer.maybe_add_extra_attribute(key, self.attribute(key));
             });
-            renderer.render(header, buf)?;
+            renderer.render(cursor)?;
         }
-        tbody.render_close(buf);
-        table.render_close(buf);
+        tbody.render_close(&mut cursor.buffer);
+        table.render_close(&mut cursor.buffer);
         Ok(())
     }
 }

--- a/packages/mrml-core/src/mj_accordion/render.rs
+++ b/packages/mrml-core/src/mj_accordion/render.rs
@@ -4,7 +4,6 @@ use std::rc::Rc;
 use super::{MjAccordion, MjAccordionChild, NAME};
 use crate::helper::size::{Pixel, Size};
 use crate::helper::tag::Tag;
-use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 const CHILDREN_ATTRIBUTES: [&str; 9] = [
@@ -54,7 +53,7 @@ impl<'e, 'h> MjAccordionRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjAccordionRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjAccordionRender<'e, 'h> {
     fn default_attribute(&self, name: &str) -> Option<&str> {
         match name {
             "border" => Some("2px solid black"),
@@ -72,8 +71,8 @@ impl<'e, 'h> Render<'h> for MjAccordionRender<'e, 'h> {
         }
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -130,7 +129,7 @@ impl<'e, 'h> Render<'h> for MjAccordionRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordion {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjAccordionRender::<'e, 'h> {
             element: self,
             header,
@@ -142,7 +141,7 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordion {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordionChild {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         match self {
             Self::MjAccordionElement(elt) => elt.renderer(header),
             Self::Comment(elt) => elt.renderer(header),

--- a/packages/mrml-core/src/mj_accordion/render.rs
+++ b/packages/mrml-core/src/mj_accordion/render.rs
@@ -14,11 +14,6 @@ const CHILDREN_ATTRIBUTES: [&str; 9] = [
     "icon-unwrapped-alt",
 ];
 
-struct MjAccordionExtra {
-    siblings: usize,
-    raw_siblings: usize,
-}
-
 const STYLE: &str = r#"noinput.mj-accordion-checkbox { display: block! important; }
 @media yahoo, only screen and (min-width:0) {
   .mj-accordion-element { display:block; }
@@ -36,7 +31,7 @@ const STYLE: &str = r#"noinput.mj-accordion-checkbox { display: block! important
 @goodbye { @gmail }
 "#;
 
-impl<'element, 'header> Renderer<'element, 'header, MjAccordion, MjAccordionExtra> {
+impl<'element, 'header> Renderer<'element, 'header, MjAccordion, ()> {
     fn update_header(&self, header: &mut VariableHeader) {
         let font_families = self.attribute("font-family");
         header.maybe_add_font_families(font_families);
@@ -44,9 +39,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjAccordion, MjAccordionExtr
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjAccordion, MjAccordionExtra>
-{
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjAccordion, ()> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "border" => Some("2px solid black"),
@@ -87,11 +80,11 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_siblings(&mut self, value: usize) {
-        self.extra.siblings = value;
+        self.siblings = value;
     }
 
     fn set_raw_siblings(&mut self, value: usize) {
-        self.extra.raw_siblings = value;
+        self.raw_siblings = value;
     }
 
     fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
@@ -128,14 +121,7 @@ impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjAcco
         &'element self,
         context: &'header RenderContext<'header>,
     ) -> Box<dyn Render<'element, 'header> + 'r> {
-        Box::new(Renderer::new(
-            context,
-            self,
-            MjAccordionExtra {
-                siblings: 1,
-                raw_siblings: 0,
-            },
-        ))
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_accordion/render.rs
+++ b/packages/mrml-core/src/mj_accordion/render.rs
@@ -106,7 +106,7 @@ impl<'root> Render<'root> for Renderer<'root, MjAccordion, ()> {
         for child in self.element.children.iter() {
             let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|key| {
-                renderer.maybe_add_extra_attribute(key, self.attribute(key));
+                renderer.maybe_add_extra_attribute(key, self.attribute(key).map(|v| v.to_owned()));
             });
             renderer.render(cursor)?;
         }

--- a/packages/mrml-core/src/mj_accordion/render.rs
+++ b/packages/mrml-core/src/mj_accordion/render.rs
@@ -15,7 +15,6 @@ const CHILDREN_ATTRIBUTES: [&str; 9] = [
 ];
 
 struct MjAccordionExtra {
-    container_width: Option<Pixel>,
     siblings: usize,
     raw_siblings: usize,
 }
@@ -78,14 +77,13 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn get_width(&self) -> Option<Size> {
-        self.extra
-            .container_width
+        self.container_width
             .as_ref()
             .map(|w| Size::Pixel(w.clone()))
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn set_siblings(&mut self, value: usize) {
@@ -134,7 +132,6 @@ impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjAcco
             context,
             self,
             MjAccordionExtra {
-                container_width: None,
                 siblings: 1,
                 raw_siblings: 0,
             },

--- a/packages/mrml-core/src/mj_accordion_element/render.rs
+++ b/packages/mrml-core/src/mj_accordion_element/render.rs
@@ -161,7 +161,7 @@ mod tests {
             },
         };
         let renderer = element.renderer(head);
-        let mut buf = String::default();
+        let mut buf = RenderBuffer::default();
         renderer.render(&opts, &mut buf).unwrap();
     }
 }

--- a/packages/mrml-core/src/mj_accordion_element/render.rs
+++ b/packages/mrml-core/src/mj_accordion_element/render.rs
@@ -3,11 +3,10 @@ use std::rc::Rc;
 
 use super::{MjAccordionElement, NAME};
 use crate::helper::condition::negation_conditional_tag;
-use crate::helper::tag::Tag;
 use crate::mj_accordion_text::MjAccordionText;
 use crate::mj_accordion_title::MjAccordionTitle;
 use crate::prelude::hash::Map;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 const CHILDREN_ATTRIBUTES: [&str; 9] = [
     "border",

--- a/packages/mrml-core/src/mj_accordion_element/render.rs
+++ b/packages/mrml-core/src/mj_accordion_element/render.rs
@@ -20,7 +20,7 @@ struct MjAccordionElementExtra {
     attributes: Map<String, String>,
 }
 
-impl<'e, 'h> Renderer<'e, 'h, MjAccordionElement, MjAccordionElementExtra> {
+impl<'root> Renderer<'root, MjAccordionElement, MjAccordionElementExtra> {
     fn render_title(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         if let Some(ref child) = self.element.children.title {
             let mut renderer = child.renderer(self.context());
@@ -63,7 +63,7 @@ impl<'e, 'h> Renderer<'e, 'h, MjAccordionElement, MjAccordionElementExtra> {
     }
 }
 
-impl<'e, 'h> Render<'e, 'h> for Renderer<'e, 'h, MjAccordionElement, MjAccordionElementExtra> {
+impl<'root> Render<'root> for Renderer<'root, MjAccordionElement, MjAccordionElementExtra> {
     fn add_extra_attribute(&mut self, key: &str, value: &str) {
         self.extra
             .attributes
@@ -74,7 +74,7 @@ impl<'e, 'h> Render<'e, 'h> for Renderer<'e, 'h, MjAccordionElement, MjAccordion
         self.extra.attributes.get(key).map(|v| v.as_str())
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -82,7 +82,7 @@ impl<'e, 'h> Render<'e, 'h> for Renderer<'e, 'h, MjAccordionElement, MjAccordion
         Some(NAME)
     }
 
-    fn context(&self) -> &'h RenderContext<'h> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -118,8 +118,11 @@ impl<'e, 'h> Render<'e, 'h> for Renderer<'e, 'h, MjAccordionElement, MjAccordion
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordionElement {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjAccordionElement {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(
             context,
             self,

--- a/packages/mrml-core/src/mj_accordion_element/render.rs
+++ b/packages/mrml-core/src/mj_accordion_element/render.rs
@@ -16,13 +16,11 @@ const CHILDREN_ATTRIBUTES: [&str; 9] = [
     "icon-unwrapped-alt",
 ];
 
-struct MjAccordionElementRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e MjAccordionElement,
-    extra: Map<String, String>,
+struct MjAccordionElementExtra {
+    attributes: Map<String, String>,
 }
 
-impl<'e, 'h> MjAccordionElementRender<'e, 'h> {
+impl<'e, 'h> Renderer<'e, 'h, MjAccordionElement, MjAccordionElementExtra> {
     fn render_title(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         if let Some(ref child) = self.element.children.title {
             let mut renderer = child.renderer(self.context());
@@ -65,13 +63,15 @@ impl<'e, 'h> MjAccordionElementRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'e, 'h> for MjAccordionElementRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for Renderer<'e, 'h, MjAccordionElement, MjAccordionElementExtra> {
     fn add_extra_attribute(&mut self, key: &str, value: &str) {
-        self.extra.insert(key.to_string(), value.to_string());
+        self.extra
+            .attributes
+            .insert(key.to_string(), value.to_string());
     }
 
     fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
-        self.extra.get(key).map(|v| v.as_str())
+        self.extra.attributes.get(key).map(|v| v.as_str())
     }
 
     fn raw_attribute(&self, key: &str) -> Option<&'e str> {
@@ -120,11 +120,13 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionElementRender<'e, 'h> {
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordionElement {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjAccordionElementRender::<'e, 'h> {
-            element: self,
+        Box::new(Renderer::new(
             context,
-            extra: Map::new(),
-        })
+            self,
+            MjAccordionElementExtra {
+                attributes: Map::new(),
+            },
+        ))
     }
 }
 

--- a/packages/mrml-core/src/mj_accordion_element/render.rs
+++ b/packages/mrml-core/src/mj_accordion_element/render.rs
@@ -23,55 +23,43 @@ struct MjAccordionElementRender<'e, 'h> {
 }
 
 impl<'e, 'h> MjAccordionElementRender<'e, 'h> {
-    fn render_title(
-        &self,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_title(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         if let Some(ref child) = self.element.children.title {
             let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
                 renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
-            renderer.render(header, buf)
+            renderer.render(cursor)
         } else {
             let child = MjAccordionTitle::default();
             let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
                 renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
-            renderer.render(header, buf)
+            renderer.render(cursor)
         }
     }
 
-    fn render_text(
-        &self,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_text(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         if let Some(ref child) = self.element.children.text {
             let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
                 renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
-            renderer.render(header, buf)
+            renderer.render(cursor)
         } else {
             let child = MjAccordionText::default();
             let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
                 renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
-            renderer.render(header, buf)
+            renderer.render(cursor)
         }
     }
 
-    fn render_children(
-        &self,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
-        self.render_title(header, buf)?;
-        self.render_text(header, buf)?;
+    fn render_children(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
+        self.render_title(cursor)?;
+        self.render_text(cursor)?;
 
         Ok(())
     }
@@ -98,7 +86,7 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionElementRender<'e, 'h> {
         self.context
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let input = Tag::new("input")
             .add_attribute("type", "checkbox")
             .add_class("mj-accordion-checkbox")
@@ -113,18 +101,18 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionElementRender<'e, 'h> {
             .maybe_add_style("background-color", self.attribute("background-color"));
         let tr = Tag::tr().maybe_add_class(self.attribute("css-class"));
 
-        tr.render_open(buf);
-        td.render_open(buf);
-        label.render_open(buf);
-        buf.start_negation_conditional_tag();
-        input.render_closed(buf);
-        buf.end_negation_conditional_tag();
-        div.render_open(buf);
-        self.render_children(header, buf)?;
-        div.render_close(buf);
-        label.render_close(buf);
-        td.render_close(buf);
-        tr.render_close(buf);
+        tr.render_open(&mut cursor.buffer);
+        td.render_open(&mut cursor.buffer);
+        label.render_open(&mut cursor.buffer);
+        cursor.buffer.start_negation_conditional_tag();
+        input.render_closed(&mut cursor.buffer);
+        cursor.buffer.end_negation_conditional_tag();
+        div.render_open(&mut cursor.buffer);
+        self.render_children(cursor)?;
+        div.render_close(&mut cursor.buffer);
+        label.render_close(&mut cursor.buffer);
+        td.render_close(&mut cursor.buffer);
+        tr.render_close(&mut cursor.buffer);
 
         Ok(())
     }
@@ -153,7 +141,6 @@ mod tests {
         let opts = RenderOptions::default();
         let head = Header::new(None, None);
         let ctx = RenderContext::new(&opts, head);
-        let mut vheader = VariableHeader::default();
 
         let element = MjAccordionElement {
             attributes: Default::default(),
@@ -169,7 +156,7 @@ mod tests {
             },
         };
         let renderer = element.renderer(&ctx);
-        let mut buf = RenderBuffer::default();
-        renderer.render(&mut vheader, &mut buf).unwrap();
+        let mut cursor = RenderCursor::default();
+        renderer.render(&mut cursor).unwrap();
     }
 }

--- a/packages/mrml-core/src/mj_accordion_element/render.rs
+++ b/packages/mrml-core/src/mj_accordion_element/render.rs
@@ -25,14 +25,16 @@ impl<'root> Renderer<'root, MjAccordionElement, MjAccordionElementExtra> {
         if let Some(ref child) = self.element.children.title {
             let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
-                renderer.maybe_add_extra_attribute(name, self.attribute(name));
+                renderer
+                    .maybe_add_extra_attribute(name, self.attribute(name).map(|v| v.to_owned()));
             });
             renderer.render(cursor)
         } else {
             let child = MjAccordionTitle::default();
             let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
-                renderer.maybe_add_extra_attribute(name, self.attribute(name));
+                renderer
+                    .maybe_add_extra_attribute(name, self.attribute(name).map(|v| v.to_owned()));
             });
             renderer.render(cursor)
         }
@@ -42,14 +44,16 @@ impl<'root> Renderer<'root, MjAccordionElement, MjAccordionElementExtra> {
         if let Some(ref child) = self.element.children.text {
             let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
-                renderer.maybe_add_extra_attribute(name, self.attribute(name));
+                renderer
+                    .maybe_add_extra_attribute(name, self.attribute(name).map(|v| v.to_owned()));
             });
             renderer.render(cursor)
         } else {
             let child = MjAccordionText::default();
             let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
-                renderer.maybe_add_extra_attribute(name, self.attribute(name));
+                renderer
+                    .maybe_add_extra_attribute(name, self.attribute(name).map(|v| v.to_owned()));
             });
             renderer.render(cursor)
         }

--- a/packages/mrml-core/src/mj_accordion_element/render.rs
+++ b/packages/mrml-core/src/mj_accordion_element/render.rs
@@ -17,7 +17,7 @@ const CHILDREN_ATTRIBUTES: [&str; 9] = [
 ];
 
 struct MjAccordionElementRender<'e, 'h> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e MjAccordionElement,
     extra: Map<String, String>,
 }
@@ -25,56 +25,53 @@ struct MjAccordionElementRender<'e, 'h> {
 impl<'e, 'h> MjAccordionElementRender<'e, 'h> {
     fn render_title(
         &self,
-        opts: &RenderOptions,
         header: &mut VariableHeader,
         buf: &mut RenderBuffer,
     ) -> Result<(), Error> {
         if let Some(ref child) = self.element.children.title {
-            let mut renderer = child.renderer(self.header);
+            let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
                 renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
-            renderer.render(opts, header, buf)
+            renderer.render(header, buf)
         } else {
             let child = MjAccordionTitle::default();
-            let mut renderer = child.renderer(self.header);
+            let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
                 renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
-            renderer.render(opts, header, buf)
+            renderer.render(header, buf)
         }
     }
 
     fn render_text(
         &self,
-        opts: &RenderOptions,
         header: &mut VariableHeader,
         buf: &mut RenderBuffer,
     ) -> Result<(), Error> {
         if let Some(ref child) = self.element.children.text {
-            let mut renderer = child.renderer(self.header);
+            let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
                 renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
-            renderer.render(opts, header, buf)
+            renderer.render(header, buf)
         } else {
             let child = MjAccordionText::default();
-            let mut renderer = child.renderer(self.header);
+            let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
                 renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
-            renderer.render(opts, header, buf)
+            renderer.render(header, buf)
         }
     }
 
     fn render_children(
         &self,
-        opts: &RenderOptions,
         header: &mut VariableHeader,
         buf: &mut RenderBuffer,
     ) -> Result<(), Error> {
-        self.render_title(opts, header, buf)?;
-        self.render_text(opts, header, buf)?;
+        self.render_title(header, buf)?;
+        self.render_text(header, buf)?;
 
         Ok(())
     }
@@ -97,16 +94,11 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionElementRender<'e, 'h> {
         Some(NAME)
     }
 
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        self.context
     }
 
-    fn render(
-        &self,
-        opts: &RenderOptions,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
         let input = Tag::new("input")
             .add_attribute("type", "checkbox")
             .add_class("mj-accordion-checkbox")
@@ -128,7 +120,7 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionElementRender<'e, 'h> {
         input.render_closed(buf);
         buf.end_negation_conditional_tag();
         div.render_open(buf);
-        self.render_children(opts, header, buf)?;
+        self.render_children(header, buf)?;
         div.render_close(buf);
         label.render_close(buf);
         td.render_close(buf);
@@ -139,10 +131,10 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionElementRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordionElement {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjAccordionElementRender::<'e, 'h> {
             element: self,
-            header,
+            context,
             extra: Map::new(),
         })
     }
@@ -160,6 +152,7 @@ mod tests {
     fn basic() {
         let opts = RenderOptions::default();
         let head = Header::new(None, None);
+        let ctx = RenderContext::new(&opts, head);
         let mut vheader = VariableHeader::default();
 
         let element = MjAccordionElement {
@@ -175,8 +168,8 @@ mod tests {
                 }),
             },
         };
-        let renderer = element.renderer(&head);
+        let renderer = element.renderer(&ctx);
         let mut buf = RenderBuffer::default();
-        renderer.render(&opts, &mut vheader, &mut buf).unwrap();
+        renderer.render(&mut vheader, &mut buf).unwrap();
     }
 }

--- a/packages/mrml-core/src/mj_accordion_element/render.rs
+++ b/packages/mrml-core/src/mj_accordion_element/render.rs
@@ -2,7 +2,6 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::{MjAccordionElement, NAME};
-use crate::helper::condition::{END_NEGATION_CONDITIONAL_TAG, START_NEGATION_CONDITIONAL_TAG};
 use crate::mj_accordion_text::MjAccordionText;
 use crate::mj_accordion_title::MjAccordionTitle;
 use crate::prelude::hash::Map;
@@ -108,9 +107,9 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionElementRender<'e, 'h> {
         tr.render_open(buf);
         td.render_open(buf);
         label.render_open(buf);
-        buf.push_str(START_NEGATION_CONDITIONAL_TAG);
+        buf.start_negation_conditional_tag();
         input.render_closed(buf);
-        buf.push_str(END_NEGATION_CONDITIONAL_TAG);
+        buf.end_negation_conditional_tag();
         div.render_open(buf);
         self.render_children(opts, buf)?;
         div.render_close(buf);

--- a/packages/mrml-core/src/mj_accordion_element/render.rs
+++ b/packages/mrml-core/src/mj_accordion_element/render.rs
@@ -67,17 +67,17 @@ impl<'e, 'h> MjAccordionElementRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjAccordionElementRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjAccordionElementRender<'e, 'h> {
     fn add_extra_attribute(&mut self, key: &str, value: &str) {
         self.extra.insert(key.to_string(), value.to_string());
     }
 
-    fn extra_attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.extra)
+    fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
+        self.extra.get(key).map(|v| v.as_str())
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -114,7 +114,7 @@ impl<'e, 'h> Render<'h> for MjAccordionElementRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordionElement {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjAccordionElementRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_accordion_element/render.rs
+++ b/packages/mrml-core/src/mj_accordion_element/render.rs
@@ -1,11 +1,8 @@
-use std::cell::{Ref, RefCell};
-use std::rc::Rc;
-
 use super::{MjAccordionElement, NAME};
 use crate::mj_accordion_text::MjAccordionText;
 use crate::mj_accordion_title::MjAccordionTitle;
 use crate::prelude::hash::Map;
-use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
+use crate::prelude::render::*;
 
 const CHILDREN_ATTRIBUTES: [&str; 9] = [
     "border",
@@ -20,49 +17,64 @@ const CHILDREN_ATTRIBUTES: [&str; 9] = [
 ];
 
 struct MjAccordionElementRender<'e, 'h> {
-    header: Rc<RefCell<Header<'h>>>,
+    header: &'h Header<'h>,
     element: &'e MjAccordionElement,
     extra: Map<String, String>,
 }
 
 impl<'e, 'h> MjAccordionElementRender<'e, 'h> {
-    fn render_title(&self, opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render_title(
+        &self,
+        opts: &RenderOptions,
+        header: &mut VariableHeader,
+        buf: &mut RenderBuffer,
+    ) -> Result<(), Error> {
         if let Some(ref child) = self.element.children.title {
-            let mut renderer = child.renderer(Rc::clone(&self.header));
+            let mut renderer = child.renderer(self.header);
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
                 renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
-            renderer.render(opts, buf)
+            renderer.render(opts, header, buf)
         } else {
             let child = MjAccordionTitle::default();
-            let mut renderer = child.renderer(Rc::clone(&self.header));
+            let mut renderer = child.renderer(self.header);
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
                 renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
-            renderer.render(opts, buf)
+            renderer.render(opts, header, buf)
         }
     }
 
-    fn render_text(&self, opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render_text(
+        &self,
+        opts: &RenderOptions,
+        header: &mut VariableHeader,
+        buf: &mut RenderBuffer,
+    ) -> Result<(), Error> {
         if let Some(ref child) = self.element.children.text {
-            let mut renderer = child.renderer(Rc::clone(&self.header));
+            let mut renderer = child.renderer(self.header);
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
                 renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
-            renderer.render(opts, buf)
+            renderer.render(opts, header, buf)
         } else {
             let child = MjAccordionText::default();
-            let mut renderer = child.renderer(Rc::clone(&self.header));
+            let mut renderer = child.renderer(self.header);
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
                 renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
-            renderer.render(opts, buf)
+            renderer.render(opts, header, buf)
         }
     }
 
-    fn render_children(&self, opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
-        self.render_title(opts, buf)?;
-        self.render_text(opts, buf)?;
+    fn render_children(
+        &self,
+        opts: &RenderOptions,
+        header: &mut VariableHeader,
+        buf: &mut RenderBuffer,
+    ) -> Result<(), Error> {
+        self.render_title(opts, header, buf)?;
+        self.render_text(opts, header, buf)?;
 
         Ok(())
     }
@@ -85,11 +97,16 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionElementRender<'e, 'h> {
         Some(NAME)
     }
 
-    fn header(&self) -> Ref<Header<'h>> {
-        self.header.borrow()
+    fn header(&self) -> &'h Header<'h> {
+        self.header
     }
 
-    fn render(&self, opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(
+        &self,
+        opts: &RenderOptions,
+        header: &mut VariableHeader,
+        buf: &mut RenderBuffer,
+    ) -> Result<(), Error> {
         let input = Tag::new("input")
             .add_attribute("type", "checkbox")
             .add_class("mj-accordion-checkbox")
@@ -111,7 +128,7 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionElementRender<'e, 'h> {
         input.render_closed(buf);
         buf.end_negation_conditional_tag();
         div.render_open(buf);
-        self.render_children(opts, buf)?;
+        self.render_children(opts, header, buf)?;
         div.render_close(buf);
         label.render_close(buf);
         td.render_close(buf);
@@ -122,7 +139,7 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionElementRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordionElement {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjAccordionElementRender::<'e, 'h> {
             element: self,
             header,
@@ -133,9 +150,6 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordionElement {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-    use std::rc::Rc;
-
     use crate::mj_accordion_element::{MjAccordionElement, MjAccordionElementChildren};
     use crate::mj_accordion_text::MjAccordionText;
     use crate::mj_accordion_title::MjAccordionTitle;
@@ -145,7 +159,9 @@ mod tests {
     #[test]
     fn basic() {
         let opts = RenderOptions::default();
-        let head = Rc::new(RefCell::new(Header::new(&None)));
+        let head = Header::new(None, None);
+        let mut vheader = VariableHeader::default();
+
         let element = MjAccordionElement {
             attributes: Default::default(),
             children: MjAccordionElementChildren {
@@ -159,8 +175,8 @@ mod tests {
                 }),
             },
         };
-        let renderer = element.renderer(head);
+        let renderer = element.renderer(&head);
         let mut buf = RenderBuffer::default();
-        renderer.render(&opts, &mut buf).unwrap();
+        renderer.render(&opts, &mut vheader, &mut buf).unwrap();
     }
 }

--- a/packages/mrml-core/src/mj_accordion_element/render.rs
+++ b/packages/mrml-core/src/mj_accordion_element/render.rs
@@ -16,25 +16,23 @@ const CHILDREN_ATTRIBUTES: [&str; 9] = [
     "icon-unwrapped-alt",
 ];
 
-struct MjAccordionElementExtra {
-    attributes: Map<String, String>,
+struct MjAccordionElementExtra<'a> {
+    attributes: Map<&'a str, &'a str>,
 }
 
-impl<'root> Renderer<'root, MjAccordionElement, MjAccordionElementExtra> {
+impl<'root> Renderer<'root, MjAccordionElement, MjAccordionElementExtra<'root>> {
     fn render_title(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         if let Some(ref child) = self.element.children.title {
             let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
-                renderer
-                    .maybe_add_extra_attribute(name, self.attribute(name).map(|v| v.to_owned()));
+                renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
             renderer.render(cursor)
         } else {
             let child = MjAccordionTitle::default();
             let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
-                renderer
-                    .maybe_add_extra_attribute(name, self.attribute(name).map(|v| v.to_owned()));
+                renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
             renderer.render(cursor)
         }
@@ -44,16 +42,14 @@ impl<'root> Renderer<'root, MjAccordionElement, MjAccordionElementExtra> {
         if let Some(ref child) = self.element.children.text {
             let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
-                renderer
-                    .maybe_add_extra_attribute(name, self.attribute(name).map(|v| v.to_owned()));
+                renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
             renderer.render(cursor)
         } else {
             let child = MjAccordionText::default();
             let mut renderer = child.renderer(self.context());
             CHILDREN_ATTRIBUTES.iter().for_each(|name| {
-                renderer
-                    .maybe_add_extra_attribute(name, self.attribute(name).map(|v| v.to_owned()));
+                renderer.maybe_add_extra_attribute(name, self.attribute(name));
             });
             renderer.render(cursor)
         }
@@ -67,15 +63,13 @@ impl<'root> Renderer<'root, MjAccordionElement, MjAccordionElementExtra> {
     }
 }
 
-impl<'root> Render<'root> for Renderer<'root, MjAccordionElement, MjAccordionElementExtra> {
-    fn add_extra_attribute(&mut self, key: &str, value: &str) {
-        self.extra
-            .attributes
-            .insert(key.to_string(), value.to_string());
+impl<'root> Render<'root> for Renderer<'root, MjAccordionElement, MjAccordionElementExtra<'root>> {
+    fn add_extra_attribute(&mut self, key: &'root str, value: &'root str) {
+        self.extra.attributes.insert(key, value);
     }
 
-    fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
-        self.extra.attributes.get(key).map(|v| v.as_str())
+    fn raw_extra_attribute(&self, key: &str) -> Option<&'root str> {
+        self.extra.attributes.get(key).copied()
     }
 
     fn raw_attribute(&self, key: &str) -> Option<&'root str> {

--- a/packages/mrml-core/src/mj_accordion_text/render.rs
+++ b/packages/mrml-core/src/mj_accordion_text/render.rs
@@ -9,11 +9,7 @@ struct MjAccordionTextRender<'e, 'h> {
 }
 
 impl<'e, 'h> MjAccordionTextRender<'e, 'h> {
-    fn render_children(
-        &self,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_children(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let td = Tag::td()
             .maybe_add_class(self.attribute("css-class"))
             .maybe_add_style("background", self.attribute("background-color"))
@@ -27,12 +23,12 @@ impl<'e, 'h> MjAccordionTextRender<'e, 'h> {
             .maybe_add_style("padding-left", self.attribute("padding-left"))
             .maybe_add_style("padding", self.attribute("padding"));
 
-        td.render_open(buf);
+        td.render_open(&mut cursor.buffer);
         for child in self.element.children.iter() {
             let renderer = child.renderer(self.context());
-            renderer.render(header, buf)?;
+            renderer.render(cursor)?;
         }
-        td.render_close(buf);
+        td.render_close(&mut cursor.buffer);
 
         Ok(())
     }
@@ -68,9 +64,9 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTextRender<'e, 'h> {
         self.context
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let font_families = self.attribute("font-family");
-        header.maybe_add_font_families(font_families);
+        cursor.header.maybe_add_font_families(font_families);
 
         let tr = Tag::tr();
         let tbody = Tag::tbody();
@@ -81,15 +77,15 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTextRender<'e, 'h> {
             .maybe_add_style("border-bottom", self.attribute("border"));
         let div = Tag::div().add_class("mj-accordion-content");
 
-        div.render_open(buf);
-        table.render_open(buf);
-        tbody.render_open(buf);
-        tr.render_open(buf);
-        self.render_children(header, buf)?;
-        tr.render_close(buf);
-        tbody.render_close(buf);
-        table.render_close(buf);
-        div.render_close(buf);
+        div.render_open(&mut cursor.buffer);
+        table.render_open(&mut cursor.buffer);
+        tbody.render_open(&mut cursor.buffer);
+        tr.render_open(&mut cursor.buffer);
+        self.render_children(cursor)?;
+        tr.render_close(&mut cursor.buffer);
+        tbody.render_close(&mut cursor.buffer);
+        table.render_close(&mut cursor.buffer);
+        div.render_close(&mut cursor.buffer);
 
         Ok(())
     }

--- a/packages/mrml-core/src/mj_accordion_text/render.rs
+++ b/packages/mrml-core/src/mj_accordion_text/render.rs
@@ -3,7 +3,7 @@ use crate::prelude::hash::Map;
 use crate::prelude::render::*;
 
 struct MjAccordionTextRender<'e, 'h> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e MjAccordionText,
     extra: Map<String, String>,
 }
@@ -11,7 +11,6 @@ struct MjAccordionTextRender<'e, 'h> {
 impl<'e, 'h> MjAccordionTextRender<'e, 'h> {
     fn render_children(
         &self,
-        opts: &RenderOptions,
         header: &mut VariableHeader,
         buf: &mut RenderBuffer,
     ) -> Result<(), Error> {
@@ -30,8 +29,8 @@ impl<'e, 'h> MjAccordionTextRender<'e, 'h> {
 
         td.render_open(buf);
         for child in self.element.children.iter() {
-            let renderer = child.renderer(self.header);
-            renderer.render(opts, header, buf)?;
+            let renderer = child.renderer(self.context());
+            renderer.render(header, buf)?;
         }
         td.render_close(buf);
 
@@ -65,16 +64,11 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTextRender<'e, 'h> {
         Some(NAME)
     }
 
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        self.context
     }
 
-    fn render(
-        &self,
-        opts: &RenderOptions,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
         let font_families = self.attribute("font-family");
         header.maybe_add_font_families(font_families);
 
@@ -91,7 +85,7 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTextRender<'e, 'h> {
         table.render_open(buf);
         tbody.render_open(buf);
         tr.render_open(buf);
-        self.render_children(opts, header, buf)?;
+        self.render_children(header, buf)?;
         tr.render_close(buf);
         tbody.render_close(buf);
         table.render_close(buf);
@@ -102,10 +96,10 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTextRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordionText {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjAccordionTextRender::<'e, 'h> {
             element: self,
-            header,
+            context,
             extra: Map::default(),
         })
     }

--- a/packages/mrml-core/src/mj_accordion_text/render.rs
+++ b/packages/mrml-core/src/mj_accordion_text/render.rs
@@ -2,11 +2,11 @@ use super::{MjAccordionText, NAME};
 use crate::prelude::hash::Map;
 use crate::prelude::render::*;
 
-struct MjAccordionTextExtra {
-    attributes: Map<String, String>,
+struct MjAccordionTextExtra<'a> {
+    attributes: Map<&'a str, &'a str>,
 }
 
-impl<'root> Renderer<'root, MjAccordionText, MjAccordionTextExtra> {
+impl<'root> Renderer<'root, MjAccordionText, MjAccordionTextExtra<'root>> {
     fn render_children(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let td = Tag::td()
             .maybe_add_class(self.attribute("css-class"))
@@ -32,7 +32,7 @@ impl<'root> Renderer<'root, MjAccordionText, MjAccordionTextExtra> {
     }
 }
 
-impl<'root> Render<'root> for Renderer<'root, MjAccordionText, MjAccordionTextExtra> {
+impl<'root> Render<'root> for Renderer<'root, MjAccordionText, MjAccordionTextExtra<'root>> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "line-height" => Some("1"),
@@ -42,14 +42,12 @@ impl<'root> Render<'root> for Renderer<'root, MjAccordionText, MjAccordionTextEx
         }
     }
 
-    fn add_extra_attribute(&mut self, key: &str, value: &str) {
-        self.extra
-            .attributes
-            .insert(key.to_string(), value.to_string());
+    fn add_extra_attribute(&mut self, key: &'root str, value: &'root str) {
+        self.extra.attributes.insert(key, value);
     }
 
-    fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
-        self.extra.attributes.get(key).map(|v| v.as_str())
+    fn raw_extra_attribute(&self, key: &str) -> Option<&'root str> {
+        self.extra.attributes.get(key).copied()
     }
 
     fn raw_attribute(&self, key: &str) -> Option<&'root str> {

--- a/packages/mrml-core/src/mj_accordion_text/render.rs
+++ b/packages/mrml-core/src/mj_accordion_text/render.rs
@@ -39,7 +39,7 @@ impl<'e, 'h> MjAccordionTextRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjAccordionTextRender<'e, 'h> {
-    fn default_attribute(&self, name: &str) -> Option<&str> {
+    fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "line-height" => Some("1"),
             "font-size" => Some("13px"),

--- a/packages/mrml-core/src/mj_accordion_text/render.rs
+++ b/packages/mrml-core/src/mj_accordion_text/render.rs
@@ -38,7 +38,7 @@ impl<'e, 'h> MjAccordionTextRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjAccordionTextRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjAccordionTextRender<'e, 'h> {
     fn default_attribute(&self, name: &str) -> Option<&str> {
         match name {
             "line-height" => Some("1"),
@@ -52,12 +52,12 @@ impl<'e, 'h> Render<'h> for MjAccordionTextRender<'e, 'h> {
         self.extra.insert(key.to_string(), value.to_string());
     }
 
-    fn extra_attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.extra)
+    fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
+        self.extra.get(key).map(|v| v.as_str())
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -87,7 +87,7 @@ impl<'e, 'h> Render<'h> for MjAccordionTextRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordionText {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjAccordionTextRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_accordion_text/render.rs
+++ b/packages/mrml-core/src/mj_accordion_text/render.rs
@@ -2,9 +2,8 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::{MjAccordionText, NAME};
-use crate::helper::tag::Tag;
 use crate::prelude::hash::Map;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 struct MjAccordionTextRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,

--- a/packages/mrml-core/src/mj_accordion_text/render.rs
+++ b/packages/mrml-core/src/mj_accordion_text/render.rs
@@ -6,7 +6,7 @@ struct MjAccordionTextExtra {
     attributes: Map<String, String>,
 }
 
-impl<'e, 'h> Renderer<'e, 'h, MjAccordionText, MjAccordionTextExtra> {
+impl<'root> Renderer<'root, MjAccordionText, MjAccordionTextExtra> {
     fn render_children(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let td = Tag::td()
             .maybe_add_class(self.attribute("css-class"))
@@ -32,7 +32,7 @@ impl<'e, 'h> Renderer<'e, 'h, MjAccordionText, MjAccordionTextExtra> {
     }
 }
 
-impl<'e, 'h> Render<'e, 'h> for Renderer<'e, 'h, MjAccordionText, MjAccordionTextExtra> {
+impl<'root> Render<'root> for Renderer<'root, MjAccordionText, MjAccordionTextExtra> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "line-height" => Some("1"),
@@ -52,7 +52,7 @@ impl<'e, 'h> Render<'e, 'h> for Renderer<'e, 'h, MjAccordionText, MjAccordionTex
         self.extra.attributes.get(key).map(|v| v.as_str())
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -60,7 +60,7 @@ impl<'e, 'h> Render<'e, 'h> for Renderer<'e, 'h, MjAccordionText, MjAccordionTex
         Some(NAME)
     }
 
-    fn context(&self) -> &'h RenderContext<'h> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -91,8 +91,11 @@ impl<'e, 'h> Render<'e, 'h> for Renderer<'e, 'h, MjAccordionText, MjAccordionTex
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordionText {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjAccordionText {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(
             context,
             self,

--- a/packages/mrml-core/src/mj_accordion_text/render.rs
+++ b/packages/mrml-core/src/mj_accordion_text/render.rs
@@ -2,13 +2,11 @@ use super::{MjAccordionText, NAME};
 use crate::prelude::hash::Map;
 use crate::prelude::render::*;
 
-struct MjAccordionTextRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e MjAccordionText,
-    extra: Map<String, String>,
+struct MjAccordionTextExtra {
+    attributes: Map<String, String>,
 }
 
-impl<'e, 'h> MjAccordionTextRender<'e, 'h> {
+impl<'e, 'h> Renderer<'e, 'h, MjAccordionText, MjAccordionTextExtra> {
     fn render_children(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let td = Tag::td()
             .maybe_add_class(self.attribute("css-class"))
@@ -34,7 +32,7 @@ impl<'e, 'h> MjAccordionTextRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'e, 'h> for MjAccordionTextRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for Renderer<'e, 'h, MjAccordionText, MjAccordionTextExtra> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "line-height" => Some("1"),
@@ -45,11 +43,13 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTextRender<'e, 'h> {
     }
 
     fn add_extra_attribute(&mut self, key: &str, value: &str) {
-        self.extra.insert(key.to_string(), value.to_string());
+        self.extra
+            .attributes
+            .insert(key.to_string(), value.to_string());
     }
 
     fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
-        self.extra.get(key).map(|v| v.as_str())
+        self.extra.attributes.get(key).map(|v| v.as_str())
     }
 
     fn raw_attribute(&self, key: &str) -> Option<&'e str> {
@@ -93,10 +93,12 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTextRender<'e, 'h> {
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordionText {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjAccordionTextRender::<'e, 'h> {
-            element: self,
+        Box::new(Renderer::new(
             context,
-            extra: Map::default(),
-        })
+            self,
+            MjAccordionTextExtra {
+                attributes: Map::new(),
+            },
+        ))
     }
 }

--- a/packages/mrml-core/src/mj_accordion_title/render.rs
+++ b/packages/mrml-core/src/mj_accordion_title/render.rs
@@ -76,7 +76,7 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTitleRender<'e, 'h> {
         self.extra.get(key).map(|v| v.as_str())
     }
 
-    fn default_attribute(&self, name: &str) -> Option<&str> {
+    fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "font-size" => Some("13px"),
             "padding" => Some("16px"),

--- a/packages/mrml-core/src/mj_accordion_title/render.rs
+++ b/packages/mrml-core/src/mj_accordion_title/render.rs
@@ -2,13 +2,11 @@ use super::{MjAccordionTitle, NAME};
 use crate::prelude::hash::Map;
 use crate::prelude::render::*;
 
-struct MjAccordionTitleRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e MjAccordionTitle,
-    extra: Map<String, String>,
+struct MjAccordionTitleExtra {
+    attributes: Map<String, String>,
 }
 
-impl<'e, 'h> MjAccordionTitleRender<'e, 'h> {
+impl<'element, 'header> Renderer<'element, 'header, MjAccordionTitle, MjAccordionTitleExtra> {
     fn set_style_img<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "none")
             .maybe_add_style("width", self.attribute("icon-width"))
@@ -65,13 +63,17 @@ impl<'e, 'h> MjAccordionTitleRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'e, 'h> for MjAccordionTitleRender<'e, 'h> {
+impl<'element, 'header> Render<'element, 'header>
+    for Renderer<'element, 'header, MjAccordionTitle, MjAccordionTitleExtra>
+{
     fn add_extra_attribute(&mut self, key: &str, value: &str) {
-        self.extra.insert(key.to_string(), value.to_string());
+        self.extra
+            .attributes
+            .insert(key.to_string(), value.to_string());
     }
 
     fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
-        self.extra.get(key).map(|v| v.as_str())
+        self.extra.attributes.get(key).map(|v| v.as_str())
     }
 
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
@@ -82,7 +84,7 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTitleRender<'e, 'h> {
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -90,7 +92,7 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTitleRender<'e, 'h> {
         Some(NAME)
     }
 
-    fn context(&self) -> &'h RenderContext<'h> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
@@ -129,12 +131,17 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTitleRender<'e, 'h> {
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordionTitle {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjAccordionTitleRender::<'e, 'h> {
-            element: self,
+impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjAccordionTitle {
+    fn renderer(
+        &'element self,
+        context: &'header RenderContext<'header>,
+    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        Box::new(Renderer::new(
             context,
-            extra: Map::new(),
-        })
+            self,
+            MjAccordionTitleExtra {
+                attributes: Map::new(),
+            },
+        ))
     }
 }

--- a/packages/mrml-core/src/mj_accordion_title/render.rs
+++ b/packages/mrml-core/src/mj_accordion_title/render.rs
@@ -3,9 +3,8 @@ use std::rc::Rc;
 
 use super::{MjAccordionTitle, NAME};
 use crate::helper::condition::negation_conditional_tag;
-use crate::helper::tag::Tag;
 use crate::prelude::hash::Map;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 struct MjAccordionTitleRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,

--- a/packages/mrml-core/src/mj_accordion_title/render.rs
+++ b/packages/mrml-core/src/mj_accordion_title/render.rs
@@ -12,7 +12,7 @@ struct MjAccordionTitleRender<'e, 'h> {
 }
 
 impl<'e, 'h> MjAccordionTitleRender<'e, 'h> {
-    fn set_style_img(&self, tag: Tag) -> Tag {
+    fn set_style_img<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "none")
             .maybe_add_style("width", self.attribute("icon-width"))
             .maybe_add_style("height", self.attribute("icon-height"))

--- a/packages/mrml-core/src/mj_accordion_title/render.rs
+++ b/packages/mrml-core/src/mj_accordion_title/render.rs
@@ -15,11 +15,7 @@ impl<'e, 'h> MjAccordionTitleRender<'e, 'h> {
             .maybe_add_style("height", self.attribute("icon-height"))
     }
 
-    fn render_title(
-        &self,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_title(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let td = Tag::td()
             .add_style("width", "100%")
             .maybe_add_style("background-color", self.attribute("background-color"))
@@ -33,12 +29,12 @@ impl<'e, 'h> MjAccordionTitleRender<'e, 'h> {
             .maybe_add_style("padding", self.attribute("padding"))
             .maybe_add_class(self.attribute("css-class"));
 
-        td.render_open(buf);
+        td.render_open(&mut cursor.buffer);
         for child in self.element.children.iter() {
             let renderer = child.renderer(self.context());
-            renderer.render(header, buf)?;
+            renderer.render(cursor)?;
         }
-        td.render_close(buf);
+        td.render_close(&mut cursor.buffer);
 
         Ok(())
     }
@@ -98,9 +94,9 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTitleRender<'e, 'h> {
         self.context
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let font_families = self.attribute("font-family");
-        header.maybe_add_font_families(font_families);
+        cursor.header.maybe_add_font_families(font_families);
 
         let tr = Tag::tr();
         let tbody = Tag::tbody();
@@ -111,23 +107,23 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTitleRender<'e, 'h> {
             .maybe_add_style("border-bottom", self.attribute("border"));
         let div = Tag::div().add_class("mj-accordion-title");
 
-        div.render_open(buf);
-        table.render_open(buf);
-        tbody.render_open(buf);
-        tr.render_open(buf);
+        div.render_open(&mut cursor.buffer);
+        table.render_open(&mut cursor.buffer);
+        tbody.render_open(&mut cursor.buffer);
+        tr.render_open(&mut cursor.buffer);
 
         if self.attribute_equals("icon-position", "right") {
-            self.render_title(header, buf)?;
-            self.render_icons(buf);
+            self.render_title(cursor)?;
+            self.render_icons(&mut cursor.buffer);
         } else {
-            self.render_icons(buf);
-            self.render_title(header, buf)?;
+            self.render_icons(&mut cursor.buffer);
+            self.render_title(cursor)?;
         }
 
-        tr.render_close(buf);
-        tbody.render_close(buf);
-        table.render_close(buf);
-        div.render_close(buf);
+        tr.render_close(&mut cursor.buffer);
+        tbody.render_close(&mut cursor.buffer);
+        table.render_close(&mut cursor.buffer);
+        div.render_close(&mut cursor.buffer);
 
         Ok(())
     }

--- a/packages/mrml-core/src/mj_accordion_title/render.rs
+++ b/packages/mrml-core/src/mj_accordion_title/render.rs
@@ -2,11 +2,11 @@ use super::{MjAccordionTitle, NAME};
 use crate::prelude::hash::Map;
 use crate::prelude::render::*;
 
-struct MjAccordionTitleExtra {
-    attributes: Map<String, String>,
+struct MjAccordionTitleExtra<'a> {
+    attributes: Map<&'a str, &'a str>,
 }
 
-impl<'root> Renderer<'root, MjAccordionTitle, MjAccordionTitleExtra> {
+impl<'root> Renderer<'root, MjAccordionTitle, MjAccordionTitleExtra<'root>> {
     fn set_style_img<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
     where
         'root: 'a,
@@ -67,15 +67,13 @@ impl<'root> Renderer<'root, MjAccordionTitle, MjAccordionTitleExtra> {
     }
 }
 
-impl<'root> Render<'root> for Renderer<'root, MjAccordionTitle, MjAccordionTitleExtra> {
-    fn add_extra_attribute(&mut self, key: &str, value: &str) {
-        self.extra
-            .attributes
-            .insert(key.to_string(), value.to_string());
+impl<'root> Render<'root> for Renderer<'root, MjAccordionTitle, MjAccordionTitleExtra<'root>> {
+    fn add_extra_attribute(&mut self, key: &'root str, value: &'root str) {
+        self.extra.attributes.insert(key, value);
     }
 
-    fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
-        self.extra.attributes.get(key).map(|v| v.as_str())
+    fn raw_extra_attribute(&self, key: &str) -> Option<&'root str> {
+        self.extra.attributes.get(key).copied()
     }
 
     fn default_attribute(&self, name: &str) -> Option<&'static str> {

--- a/packages/mrml-core/src/mj_accordion_title/render.rs
+++ b/packages/mrml-core/src/mj_accordion_title/render.rs
@@ -2,7 +2,6 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::{MjAccordionTitle, NAME};
-use crate::helper::condition::{END_NEGATION_CONDITIONAL_TAG, START_NEGATION_CONDITIONAL_TAG};
 use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
 
@@ -60,12 +59,12 @@ impl<'e, 'h> MjAccordionTitleRender<'e, 'h> {
             .maybe_add_style("vertical-align", self.attribute("icon-align"))
             .add_class("mj-accordion-ico");
 
-        buf.push_str(START_NEGATION_CONDITIONAL_TAG);
+        buf.start_negation_conditional_tag();
         td.render_open(buf);
         img_more.render_closed(buf);
         img_less.render_closed(buf);
         td.render_close(buf);
-        buf.push_str(END_NEGATION_CONDITIONAL_TAG);
+        buf.end_negation_conditional_tag();
     }
 }
 

--- a/packages/mrml-core/src/mj_accordion_title/render.rs
+++ b/packages/mrml-core/src/mj_accordion_title/render.rs
@@ -6,7 +6,7 @@ struct MjAccordionTitleExtra {
     attributes: Map<String, String>,
 }
 
-impl<'element, 'header> Renderer<'element, 'header, MjAccordionTitle, MjAccordionTitleExtra> {
+impl<'root> Renderer<'root, MjAccordionTitle, MjAccordionTitleExtra> {
     fn set_style_img<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "none")
             .maybe_add_style("width", self.attribute("icon-width"))
@@ -63,9 +63,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjAccordionTitle, MjAccordio
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjAccordionTitle, MjAccordionTitleExtra>
-{
+impl<'root> Render<'root> for Renderer<'root, MjAccordionTitle, MjAccordionTitleExtra> {
     fn add_extra_attribute(&mut self, key: &str, value: &str) {
         self.extra
             .attributes
@@ -84,7 +82,7 @@ impl<'element, 'header> Render<'element, 'header>
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -92,7 +90,7 @@ impl<'element, 'header> Render<'element, 'header>
         Some(NAME)
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -131,11 +129,11 @@ impl<'element, 'header> Render<'element, 'header>
     }
 }
 
-impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjAccordionTitle {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjAccordionTitle {
     fn renderer(
-        &'element self,
-        context: &'header RenderContext<'header>,
-    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(
             context,
             self,

--- a/packages/mrml-core/src/mj_accordion_title/render.rs
+++ b/packages/mrml-core/src/mj_accordion_title/render.rs
@@ -67,13 +67,13 @@ impl<'e, 'h> MjAccordionTitleRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjAccordionTitleRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjAccordionTitleRender<'e, 'h> {
     fn add_extra_attribute(&mut self, key: &str, value: &str) {
         self.extra.insert(key.to_string(), value.to_string());
     }
 
-    fn extra_attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.extra)
+    fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
+        self.extra.get(key).map(|v| v.as_str())
     }
 
     fn default_attribute(&self, name: &str) -> Option<&str> {
@@ -84,8 +84,8 @@ impl<'e, 'h> Render<'h> for MjAccordionTitleRender<'e, 'h> {
         }
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -119,7 +119,7 @@ impl<'e, 'h> Render<'h> for MjAccordionTitleRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordionTitle {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjAccordionTitleRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_accordion_title/render.rs
+++ b/packages/mrml-core/src/mj_accordion_title/render.rs
@@ -3,7 +3,7 @@ use crate::prelude::hash::Map;
 use crate::prelude::render::*;
 
 struct MjAccordionTitleRender<'e, 'h> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e MjAccordionTitle,
     extra: Map<String, String>,
 }
@@ -17,7 +17,6 @@ impl<'e, 'h> MjAccordionTitleRender<'e, 'h> {
 
     fn render_title(
         &self,
-        opts: &RenderOptions,
         header: &mut VariableHeader,
         buf: &mut RenderBuffer,
     ) -> Result<(), Error> {
@@ -36,8 +35,8 @@ impl<'e, 'h> MjAccordionTitleRender<'e, 'h> {
 
         td.render_open(buf);
         for child in self.element.children.iter() {
-            let renderer = child.renderer(self.header);
-            renderer.render(opts, header, buf)?;
+            let renderer = child.renderer(self.context());
+            renderer.render(header, buf)?;
         }
         td.render_close(buf);
 
@@ -95,16 +94,11 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTitleRender<'e, 'h> {
         Some(NAME)
     }
 
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        self.context
     }
 
-    fn render(
-        &self,
-        opts: &RenderOptions,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
         let font_families = self.attribute("font-family");
         header.maybe_add_font_families(font_families);
 
@@ -123,11 +117,11 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTitleRender<'e, 'h> {
         tr.render_open(buf);
 
         if self.attribute_equals("icon-position", "right") {
-            self.render_title(opts, header, buf)?;
+            self.render_title(header, buf)?;
             self.render_icons(buf);
         } else {
             self.render_icons(buf);
-            self.render_title(opts, header, buf)?;
+            self.render_title(header, buf)?;
         }
 
         tr.render_close(buf);
@@ -140,10 +134,10 @@ impl<'e, 'h> Render<'e, 'h> for MjAccordionTitleRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjAccordionTitle {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjAccordionTitleRender::<'e, 'h> {
             element: self,
-            header,
+            context,
             extra: Map::new(),
         })
     }

--- a/packages/mrml-core/src/mj_accordion_title/render.rs
+++ b/packages/mrml-core/src/mj_accordion_title/render.rs
@@ -7,7 +7,11 @@ struct MjAccordionTitleExtra {
 }
 
 impl<'root> Renderer<'root, MjAccordionTitle, MjAccordionTitleExtra> {
-    fn set_style_img<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_img<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.add_style("display", "none")
             .maybe_add_style("width", self.attribute("icon-width"))
             .maybe_add_style("height", self.attribute("icon-height"))

--- a/packages/mrml-core/src/mj_body/children.rs
+++ b/packages/mrml-core/src/mj_body/children.rs
@@ -82,12 +82,12 @@ impl MjBodyChild {
 }
 
 #[cfg(feature = "render")]
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjBodyChild {
+impl<'r, 'e: 'r, 'h: 'r + 'e> Renderable<'r, 'e, 'h> for MjBodyChild {
     fn is_raw(&self) -> bool {
         self.as_renderable().is_raw()
     }
 
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         self.as_renderable().renderer(header)
     }
 }

--- a/packages/mrml-core/src/mj_body/children.rs
+++ b/packages/mrml-core/src/mj_body/children.rs
@@ -1,8 +1,3 @@
-#[cfg(feature = "render")]
-use std::cell::RefCell;
-#[cfg(feature = "render")]
-use std::rc::Rc;
-
 use crate::comment::Comment;
 use crate::mj_accordion::MjAccordion;
 use crate::mj_button::MjButton;
@@ -87,7 +82,7 @@ impl<'r, 'e: 'r, 'h: 'r + 'e> Renderable<'r, 'e, 'h> for MjBodyChild {
         self.as_renderable().is_raw()
     }
 
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         self.as_renderable().renderer(header)
     }
 }

--- a/packages/mrml-core/src/mj_body/children.rs
+++ b/packages/mrml-core/src/mj_body/children.rs
@@ -50,7 +50,9 @@ pub enum MjBodyChild {
 
 impl MjBodyChild {
     #[cfg(feature = "render")]
-    pub fn as_renderable<'r, 'e: 'r, 'h: 'r>(&'e self) -> &'e (dyn Renderable<'r, 'e, 'h> + 'e) {
+    pub fn as_renderable<'render, 'root: 'render>(
+        &'root self,
+    ) -> &'root (dyn Renderable<'render, 'root> + 'root) {
         match self {
             Self::Comment(elt) => elt,
             Self::MjAccordion(elt) => elt,
@@ -77,12 +79,15 @@ impl MjBodyChild {
 }
 
 #[cfg(feature = "render")]
-impl<'r, 'e: 'r, 'h: 'r + 'e> Renderable<'r, 'e, 'h> for MjBodyChild {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjBodyChild {
     fn is_raw(&self) -> bool {
         self.as_renderable().is_raw()
     }
 
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         self.as_renderable().renderer(context)
     }
 }

--- a/packages/mrml-core/src/mj_body/children.rs
+++ b/packages/mrml-core/src/mj_body/children.rs
@@ -18,7 +18,7 @@ use crate::mj_text::MjText;
 use crate::mj_wrapper::MjWrapper;
 use crate::node::Node;
 #[cfg(feature = "render")]
-use crate::prelude::render::{Header, Render, Renderable};
+use crate::prelude::render::{Render, RenderContext, Renderable};
 use crate::text::Text;
 
 #[derive(Debug, mrml_macros::MrmlChildren)]
@@ -82,7 +82,7 @@ impl<'r, 'e: 'r, 'h: 'r + 'e> Renderable<'r, 'e, 'h> for MjBodyChild {
         self.as_renderable().is_raw()
     }
 
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        self.as_renderable().renderer(header)
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+        self.as_renderable().renderer(context)
     }
 }

--- a/packages/mrml-core/src/mj_body/render.rs
+++ b/packages/mrml-core/src/mj_body/render.rs
@@ -4,7 +4,7 @@ use super::MjBody;
 use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
-impl<'element, 'header> Renderer<'element, 'header, MjBody, ()> {
+impl<'root> Renderer<'root, MjBody, ()> {
     fn get_width(&self) -> Option<Pixel> {
         self.attribute("width")
             .and_then(|value| Pixel::try_from(value.as_str()).ok())
@@ -56,8 +56,8 @@ impl<'element, 'header> Renderer<'element, 'header, MjBody, ()> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjBody, ()> {
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+impl<'root> Render<'root> for Renderer<'root, MjBody, ()> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -68,7 +68,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         }
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -82,11 +82,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjBody {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjBody {
     fn renderer(
-        &'element self,
-        context: &'header RenderContext<'header>,
-    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/mj_body/render.rs
+++ b/packages/mrml-core/src/mj_body/render.rs
@@ -77,7 +77,7 @@ impl<'e, 'h> Render<'e, 'h> for MjBodyRender<'e, 'h> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
-    fn default_attribute(&self, key: &str) -> Option<&str> {
+    fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "width" => Some("600px"),
             _ => None,

--- a/packages/mrml-core/src/mj_body/render.rs
+++ b/packages/mrml-core/src/mj_body/render.rs
@@ -37,15 +37,11 @@ impl<'e, 'h> MjBodyRender<'e, 'h> {
         }
     }
 
-    fn render_content(
-        &self,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_content(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let div = self.get_content_div_tag();
         let element_width = self.get_width();
 
-        div.render_open(buf);
+        div.render_open(&mut cursor.buffer);
         let raw_siblings = self
             .element
             .children
@@ -58,9 +54,9 @@ impl<'e, 'h> MjBodyRender<'e, 'h> {
             renderer.set_index(index);
             renderer.set_raw_siblings(raw_siblings);
             renderer.set_siblings(self.element.children.len());
-            renderer.render(header, buf)?;
+            renderer.render(cursor)?;
         }
-        div.render_close(buf);
+        div.render_close(&mut cursor.buffer);
         Ok(())
     }
 }
@@ -81,12 +77,12 @@ impl<'e, 'h> Render<'e, 'h> for MjBodyRender<'e, 'h> {
         self.context
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let body = self.get_body_tag();
-        body.render_open(buf);
-        self.render_preview(buf);
-        self.render_content(header, buf)?;
-        body.render_close(buf);
+        body.render_open(&mut cursor.buffer);
+        self.render_preview(&mut cursor.buffer);
+        self.render_content(cursor)?;
+        body.render_close(&mut cursor.buffer);
         Ok(())
     }
 }

--- a/packages/mrml-core/src/mj_body/render.rs
+++ b/packages/mrml-core/src/mj_body/render.rs
@@ -27,7 +27,7 @@ impl<'e, 'h> MjBodyRender<'e, 'h> {
             .maybe_add_attribute("lang", self.header().lang().map(ToString::to_string))
     }
 
-    fn set_body_style(&self, tag: Tag) -> Tag {
+    fn set_body_style<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("background-color", self.attribute("background-color"))
     }
 

--- a/packages/mrml-core/src/mj_body/render.rs
+++ b/packages/mrml-core/src/mj_body/render.rs
@@ -5,7 +5,6 @@ use std::rc::Rc;
 use super::MjBody;
 use crate::helper::size::Pixel;
 use crate::helper::tag::Tag;
-use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 struct MjBodyRender<'e, 'h> {
@@ -73,9 +72,9 @@ impl<'e, 'h> MjBodyRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjBodyRender<'e, 'h> {
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+impl<'e, 'h> Render<'e, 'h> for MjBodyRender<'e, 'h> {
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn default_attribute(&self, key: &str) -> Option<&str> {
@@ -97,7 +96,7 @@ impl<'e, 'h> Render<'h> for MjBodyRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjBody {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjBodyRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_body/render.rs
+++ b/packages/mrml-core/src/mj_body/render.rs
@@ -7,7 +7,7 @@ use crate::prelude::render::*;
 impl<'root> Renderer<'root, MjBody, ()> {
     fn get_width(&self) -> Option<Pixel> {
         self.attribute("width")
-            .and_then(|value| Pixel::try_from(value.as_str()).ok())
+            .and_then(|value| Pixel::try_from(value).ok())
     }
 
     fn get_body_tag(&self) -> Tag {
@@ -20,7 +20,11 @@ impl<'root> Renderer<'root, MjBody, ()> {
             .maybe_add_attribute("lang", self.context.header.lang().map(ToString::to_string))
     }
 
-    fn set_body_style<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_body_style<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.maybe_add_style("background-color", self.attribute("background-color"))
     }
 

--- a/packages/mrml-core/src/mj_body/render.rs
+++ b/packages/mrml-core/src/mj_body/render.rs
@@ -4,12 +4,7 @@ use super::MjBody;
 use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
-struct MjBodyRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e MjBody,
-}
-
-impl<'e, 'h> MjBodyRender<'e, 'h> {
+impl<'element, 'header> Renderer<'element, 'header, MjBody, ()> {
     fn get_width(&self) -> Option<Pixel> {
         self.attribute("width")
             .and_then(|value| Pixel::try_from(value.as_str()).ok())
@@ -61,8 +56,8 @@ impl<'e, 'h> MjBodyRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'e, 'h> for MjBodyRender<'e, 'h> {
-    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjBody, ()> {
+    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -73,7 +68,7 @@ impl<'e, 'h> Render<'e, 'h> for MjBodyRender<'e, 'h> {
         }
     }
 
-    fn context(&self) -> &'h RenderContext<'h> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
@@ -87,12 +82,12 @@ impl<'e, 'h> Render<'e, 'h> for MjBodyRender<'e, 'h> {
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjBody {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjBodyRender::<'e, 'h> {
-            element: self,
-            context,
-        })
+impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjBody {
+    fn renderer(
+        &'element self,
+        context: &'header RenderContext<'header>,
+    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_body/render.rs
+++ b/packages/mrml-core/src/mj_body/render.rs
@@ -4,8 +4,7 @@ use std::rc::Rc;
 
 use super::MjBody;
 use crate::helper::size::Pixel;
-use crate::helper::tag::Tag;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 struct MjBodyRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,

--- a/packages/mrml-core/src/mj_button/render.rs
+++ b/packages/mrml-core/src/mj_button/render.rs
@@ -2,7 +2,7 @@ use super::{MjButton, NAME};
 use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
-impl<'element, 'header> Renderer<'element, 'header, MjButton, ()> {
+impl<'root> Renderer<'root, MjButton, ()> {
     fn content_width(&self) -> Option<String> {
         if let Some(width) = self.attribute_as_pixel("width") {
             let pad_left = self
@@ -76,7 +76,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjButton, ()> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjButton, ()> {
+impl<'root> Render<'root> for Renderer<'root, MjButton, ()> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("center"),
@@ -98,7 +98,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -106,7 +106,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         Some(NAME)
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -150,11 +150,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjButton {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjButton {
     fn renderer(
-        &'element self,
-        context: &'header RenderContext<'header>,
-    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/mj_button/render.rs
+++ b/packages/mrml-core/src/mj_button/render.rs
@@ -2,12 +2,7 @@ use super::{MjButton, NAME};
 use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
-struct MjButtonRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e MjButton,
-}
-
-impl<'e, 'h> MjButtonRender<'e, 'h> {
+impl<'element, 'header> Renderer<'element, 'header, MjButton, ()> {
     fn content_width(&self) -> Option<String> {
         if let Some(width) = self.attribute_as_pixel("width") {
             let pad_left = self
@@ -81,7 +76,7 @@ impl<'e, 'h> MjButtonRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'e, 'h> for MjButtonRender<'e, 'h> {
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjButton, ()> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("center"),
@@ -103,7 +98,7 @@ impl<'e, 'h> Render<'e, 'h> for MjButtonRender<'e, 'h> {
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -111,7 +106,7 @@ impl<'e, 'h> Render<'e, 'h> for MjButtonRender<'e, 'h> {
         Some(NAME)
     }
 
-    fn context(&self) -> &'h RenderContext<'h> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
@@ -155,12 +150,12 @@ impl<'e, 'h> Render<'e, 'h> for MjButtonRender<'e, 'h> {
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjButton {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjButtonRender::<'e, 'h> {
-            element: self,
-            context,
-        })
+impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjButton {
+    fn renderer(
+        &'element self,
+        context: &'header RenderContext<'header>,
+    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_button/render.rs
+++ b/packages/mrml-core/src/mj_button/render.rs
@@ -32,14 +32,10 @@ impl<'e, 'h> MjButtonRender<'e, 'h> {
         }
     }
 
-    fn render_children(
-        &self,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_children(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         for child in self.element.children.iter() {
             let renderer = child.renderer(self.context());
-            renderer.render(header, buf)?;
+            renderer.render(cursor)?;
         }
         Ok(())
     }
@@ -119,9 +115,9 @@ impl<'e, 'h> Render<'e, 'h> for MjButtonRender<'e, 'h> {
         self.context
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let font_family = self.attribute("font-family");
-        header.maybe_add_font_families(font_family);
+        cursor.header.maybe_add_font_families(font_family);
 
         let table = self.set_style_table(Tag::table_presentation());
         let tbody = Tag::tbody();
@@ -143,17 +139,17 @@ impl<'e, 'h> Render<'e, 'h> for MjButtonRender<'e, 'h> {
             );
         let link = self.set_style_content(link);
 
-        table.render_open(buf);
-        tbody.render_open(buf);
-        tr.render_open(buf);
-        td.render_open(buf);
-        link.render_open(buf);
-        self.render_children(header, buf)?;
-        link.render_close(buf);
-        td.render_close(buf);
-        tr.render_close(buf);
-        tbody.render_close(buf);
-        table.render_close(buf);
+        table.render_open(&mut cursor.buffer);
+        tbody.render_open(&mut cursor.buffer);
+        tr.render_open(&mut cursor.buffer);
+        td.render_open(&mut cursor.buffer);
+        link.render_open(&mut cursor.buffer);
+        self.render_children(cursor)?;
+        link.render_close(&mut cursor.buffer);
+        td.render_close(&mut cursor.buffer);
+        tr.render_close(&mut cursor.buffer);
+        tbody.render_close(&mut cursor.buffer);
+        table.render_close(&mut cursor.buffer);
 
         Ok(())
     }

--- a/packages/mrml-core/src/mj_button/render.rs
+++ b/packages/mrml-core/src/mj_button/render.rs
@@ -43,13 +43,13 @@ impl<'e, 'h> MjButtonRender<'e, 'h> {
         Ok(())
     }
 
-    fn set_style_table(&self, tag: Tag) -> Tag {
+    fn set_style_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("border-collapse", "separate")
             .maybe_add_style("width", self.attribute("width"))
             .add_style("line-height", "100%")
     }
 
-    fn set_style_td(&self, tag: Tag) -> Tag {
+    fn set_style_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("border", self.attribute("border"))
             .maybe_add_style("border-bottom", self.attribute("border-bottom"))
             .maybe_add_style("border-left", self.attribute("border-left"))
@@ -64,7 +64,7 @@ impl<'e, 'h> MjButtonRender<'e, 'h> {
             .maybe_add_style("background", self.attribute("background-color"))
     }
 
-    fn set_style_content(&self, tag: Tag) -> Tag {
+    fn set_style_content<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "inline-block")
             .maybe_add_style("width", self.content_width())
             .maybe_add_style("background", self.attribute("background-color"))

--- a/packages/mrml-core/src/mj_button/render.rs
+++ b/packages/mrml-core/src/mj_button/render.rs
@@ -35,13 +35,21 @@ impl<'root> Renderer<'root, MjButton, ()> {
         Ok(())
     }
 
-    fn set_style_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_table<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.add_style("border-collapse", "separate")
             .maybe_add_style("width", self.attribute("width"))
             .add_style("line-height", "100%")
     }
 
-    fn set_style_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_td<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.maybe_add_style("border", self.attribute("border"))
             .maybe_add_style("border-bottom", self.attribute("border-bottom"))
             .maybe_add_style("border-left", self.attribute("border-left"))
@@ -56,7 +64,11 @@ impl<'root> Renderer<'root, MjButton, ()> {
             .maybe_add_style("background", self.attribute("background-color"))
     }
 
-    fn set_style_content<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_content<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.add_style("display", "inline-block")
             .maybe_add_style("width", self.content_width())
             .maybe_add_style("background", self.attribute("background-color"))

--- a/packages/mrml-core/src/mj_button/render.rs
+++ b/packages/mrml-core/src/mj_button/render.rs
@@ -3,8 +3,7 @@ use std::rc::Rc;
 
 use super::{MjButton, NAME};
 use crate::helper::size::Pixel;
-use crate::helper::tag::Tag;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 struct MjButtonRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,

--- a/packages/mrml-core/src/mj_button/render.rs
+++ b/packages/mrml-core/src/mj_button/render.rs
@@ -4,7 +4,6 @@ use std::rc::Rc;
 use super::{MjButton, NAME};
 use crate::helper::size::Pixel;
 use crate::helper::tag::Tag;
-use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 struct MjButtonRender<'e, 'h> {
@@ -88,7 +87,7 @@ impl<'e, 'h> MjButtonRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjButtonRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjButtonRender<'e, 'h> {
     fn default_attribute(&self, key: &str) -> Option<&str> {
         match key {
             "align" => Some("center"),
@@ -110,8 +109,8 @@ impl<'e, 'h> Render<'h> for MjButtonRender<'e, 'h> {
         }
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -153,7 +152,7 @@ impl<'e, 'h> Render<'h> for MjButtonRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjButton {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjButtonRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_button/render.rs
+++ b/packages/mrml-core/src/mj_button/render.rs
@@ -3,7 +3,7 @@ use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
 struct MjButtonRender<'e, 'h> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e MjButton,
 }
 
@@ -34,13 +34,12 @@ impl<'e, 'h> MjButtonRender<'e, 'h> {
 
     fn render_children(
         &self,
-        opts: &RenderOptions,
         header: &mut VariableHeader,
         buf: &mut RenderBuffer,
     ) -> Result<(), Error> {
         for child in self.element.children.iter() {
-            let renderer = child.renderer(self.header);
-            renderer.render(opts, header, buf)?;
+            let renderer = child.renderer(self.context());
+            renderer.render(header, buf)?;
         }
         Ok(())
     }
@@ -116,16 +115,11 @@ impl<'e, 'h> Render<'e, 'h> for MjButtonRender<'e, 'h> {
         Some(NAME)
     }
 
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        self.context
     }
 
-    fn render(
-        &self,
-        opts: &RenderOptions,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
         let font_family = self.attribute("font-family");
         header.maybe_add_font_families(font_family);
 
@@ -154,7 +148,7 @@ impl<'e, 'h> Render<'e, 'h> for MjButtonRender<'e, 'h> {
         tr.render_open(buf);
         td.render_open(buf);
         link.render_open(buf);
-        self.render_children(opts, header, buf)?;
+        self.render_children(header, buf)?;
         link.render_close(buf);
         td.render_close(buf);
         tr.render_close(buf);
@@ -166,10 +160,10 @@ impl<'e, 'h> Render<'e, 'h> for MjButtonRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjButton {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjButtonRender::<'e, 'h> {
             element: self,
-            header,
+            context,
         })
     }
 }

--- a/packages/mrml-core/src/mj_button/render.rs
+++ b/packages/mrml-core/src/mj_button/render.rs
@@ -88,7 +88,7 @@ impl<'e, 'h> MjButtonRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjButtonRender<'e, 'h> {
-    fn default_attribute(&self, key: &str) -> Option<&str> {
+    fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("center"),
             "background-color" => Some("#414141"),

--- a/packages/mrml-core/src/mj_carousel/render.rs
+++ b/packages/mrml-core/src/mj_carousel/render.rs
@@ -20,8 +20,6 @@ fn repeat(count: usize, value: &str) -> String {
 }
 
 struct MjCarouselExtra {
-    siblings: usize,
-    raw_siblings: usize,
     id: String,
 }
 
@@ -426,11 +424,11 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_siblings(&mut self, value: usize) {
-        self.extra.siblings = value;
+        self.siblings = value;
     }
 
     fn set_raw_siblings(&mut self, value: usize) {
-        self.extra.raw_siblings = value;
+        self.raw_siblings = value;
     }
 
     fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
@@ -463,15 +461,7 @@ impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjCaro
         context: &'header RenderContext<'header>,
     ) -> Box<dyn Render<'element, 'header> + 'r> {
         let id = context.generator.next_id();
-        Box::new(Renderer::new(
-            context,
-            self,
-            MjCarouselExtra {
-                siblings: 1,
-                raw_siblings: 0,
-                id,
-            },
-        ))
+        Box::new(Renderer::new(context, self, MjCarouselExtra { id }))
     }
 }
 

--- a/packages/mrml-core/src/mj_carousel/render.rs
+++ b/packages/mrml-core/src/mj_carousel/render.rs
@@ -238,30 +238,30 @@ impl<'e, 'h> MjCarouselRender<'e, 'h> {
         let length = self.element.children.len();
         let mut style = vec![
             Style::default()
-                .add_str_selector(".mj-carousel")
-                .add_str_content("-webkit-user-select: none;")
-                .add_str_content("-moz-user-select: none;")
-                .add_str_content("user-select: none;")
+                .add_selector(".mj-carousel")
+                .add_content("-webkit-user-select: none;")
+                .add_content("-moz-user-select: none;")
+                .add_content("user-select: none;")
                 .to_string(),
             Style::default()
                 .add_selector(format!(".mj-carousel-{}-icons-cell", self.id))
-                .add_str_content("display: table-cell !important;")
+                .add_content("display: table-cell !important;")
                 .add_content(format!(
                     "width: {} !important;",
                     self.attribute("icon-width").unwrap()
                 ))
                 .to_string(),
             Style::default()
-                .add_str_selector(".mj-carousel-radio")
-                .add_str_selector(".mj-carousel-next")
-                .add_str_selector(".mj-carousel-previous")
-                .add_str_content("display: none !important;")
+                .add_selector(".mj-carousel-radio")
+                .add_selector(".mj-carousel-next")
+                .add_selector(".mj-carousel-previous")
+                .add_content("display: none !important;")
                 .to_string(),
             Style::default()
-                .add_str_selector(".mj-carousel-thumbnail")
-                .add_str_selector(".mj-carousel-next")
-                .add_str_selector(".mj-carousel-previous")
-                .add_str_content("touch-action: manipulation;")
+                .add_selector(".mj-carousel-thumbnail")
+                .add_selector(".mj-carousel-next")
+                .add_selector(".mj-carousel-previous")
+                .add_content("touch-action: manipulation;")
                 .to_string(),
         ];
         style.push(
@@ -273,7 +273,7 @@ impl<'e, 'h> MjCarouselRender<'e, 'h> {
                         self.id, ext
                     ))
                 })
-                .add_str_content("display: none !important;")
+                .add_content("display: none !important;")
                 .to_string(),
         );
         style.push(
@@ -285,11 +285,11 @@ impl<'e, 'h> MjCarouselRender<'e, 'h> {
                         self.id, idx + 1, ext, idx + 1
                     ))
                 })
-                .add_str_content("display: block !important;").to_string(),
+                .add_content("display: block !important;").to_string(),
         );
         let base = Style::default()
-            .add_str_selector(".mj-carousel-previous-icons")
-            .add_str_selector(".mj-carousel-next-icons");
+            .add_selector(".mj-carousel-previous-icons")
+            .add_selector(".mj-carousel-next-icons");
         let base = (0..length).fold(base, |res, idx| {
             let ext = repeat(length - idx - 1, "+ * ");
             let index = (idx + 1) % length + 1;
@@ -309,10 +309,7 @@ impl<'e, 'h> MjCarouselRender<'e, 'h> {
                 self.id, idx + 1, ext, index
             ))
         });
-        style.push(
-            base.add_str_content("display: block !important;")
-                .to_string(),
-        );
+        style.push(base.add_content("display: block !important;").to_string());
         let base = (0..length).fold(Style::default(), |res, idx| {
             let ext = repeat(length - idx - 1, "+ * ");
             res.add_selector(format!(".mj-carousel-{}-radio-{}:checked {}+ .mj-carousel-content .mj-carousel-{}-thumbnail-{}", self.id, idx + 1, ext, self.id, idx + 1))
@@ -326,9 +323,9 @@ impl<'e, 'h> MjCarouselRender<'e, 'h> {
         );
         style.push(
             Style::default()
-                .add_str_selector(".mj-carousel-image img + div")
-                .add_str_selector(".mj-carousel-thumbnail img + div")
-                .add_str_content("display: none !important;")
+                .add_selector(".mj-carousel-image img + div")
+                .add_selector(".mj-carousel-thumbnail img + div")
+                .add_content("display: none !important;")
                 .to_string(),
         );
         style.push(
@@ -340,12 +337,12 @@ impl<'e, 'h> MjCarouselRender<'e, 'h> {
                         self.id, ext
                     ))
                 })
-                .add_str_content("display: none !important;")
+                .add_content("display: none !important;")
                 .to_string(),
         );
         style.push(
             Style::default()
-                .add_str_selector(".mj-carousel-thumbnail:hover")
+                .add_selector(".mj-carousel-thumbnail:hover")
                 .add_content(format!(
                     "border-color: {} !important;",
                     self.attribute("tb-hover-border-color").unwrap()
@@ -355,7 +352,7 @@ impl<'e, 'h> MjCarouselRender<'e, 'h> {
         style.push((0..length).fold(Style::default(), |res, idx| {
             let ext = repeat(length - idx - 1, "+ * ");
             res.add_selector(format!(".mj-carousel-{}-thumbnail-{}:hover {}+ .mj-carousel-main .mj-carousel-image-{}", self.id, idx + 1, ext, idx + 1))
-        }).add_str_content("display: block !important;").to_string());
+        }).add_content("display: block !important;").to_string());
         style.push(".mj-carousel noinput { display:block !important; }".into());
         style.push(
             ".mj-carousel noinput .mj-carousel-image-1 { display: block !important;  }".into(),

--- a/packages/mrml-core/src/mj_carousel/render.rs
+++ b/packages/mrml-core/src/mj_carousel/render.rs
@@ -5,8 +5,7 @@ use super::{MjCarousel, MjCarouselChild, NAME};
 use crate::helper::condition::{mso_conditional_tag, mso_negation_conditional_tag};
 use crate::helper::size::{Pixel, Size};
 use crate::helper::style::Style;
-use crate::helper::tag::Tag;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjCarouselChild {
     fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {

--- a/packages/mrml-core/src/mj_carousel/render.rs
+++ b/packages/mrml-core/src/mj_carousel/render.rs
@@ -6,11 +6,10 @@ use crate::helper::condition::{mso_conditional_tag, mso_negation_conditional_tag
 use crate::helper::size::{Pixel, Size};
 use crate::helper::style::Style;
 use crate::helper::tag::Tag;
-use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjCarouselChild {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         match self {
             Self::MjCarouselImage(elt) => elt.renderer(header),
             Self::Comment(elt) => elt.renderer(header),
@@ -391,7 +390,7 @@ impl<'e, 'h> MjCarouselRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjCarouselRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjCarouselRender<'e, 'h> {
     fn default_attribute(&self, name: &str) -> Option<&str> {
         match name {
             "align" => Some("center"),
@@ -408,8 +407,8 @@ impl<'e, 'h> Render<'h> for MjCarouselRender<'e, 'h> {
         }
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -459,7 +458,7 @@ impl<'e, 'h> Render<'h> for MjCarouselRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjCarousel {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         let id = header.borrow().next_id();
         Box::new(MjCarouselRender::<'e, 'h> {
             element: self,

--- a/packages/mrml-core/src/mj_carousel/render.rs
+++ b/packages/mrml-core/src/mj_carousel/render.rs
@@ -3,11 +3,11 @@ use crate::helper::size::{Pixel, Size};
 use crate::helper::style::Style;
 use crate::prelude::render::*;
 
-impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjCarouselChild {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjCarouselChild {
     fn renderer(
-        &'element self,
-        context: &'header RenderContext<'header>,
-    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         match self {
             Self::MjCarouselImage(elt) => elt.renderer(context),
             Self::Comment(elt) => elt.renderer(context),
@@ -23,7 +23,7 @@ struct MjCarouselExtra {
     id: String,
 }
 
-impl<'element, 'header> Renderer<'element, 'header, MjCarousel, MjCarouselExtra> {
+impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
     fn get_thumbnails_width(&self) -> Pixel {
         let count = self.element.children.len();
         if count == 0 {
@@ -382,9 +382,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjCarousel, MjCarouselExtra>
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjCarousel, MjCarouselExtra>
-{
+impl<'root> Render<'root> for Renderer<'root, MjCarousel, MjCarouselExtra> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "align" => Some("center"),
@@ -401,7 +399,7 @@ impl<'element, 'header> Render<'element, 'header>
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -409,7 +407,7 @@ impl<'element, 'header> Render<'element, 'header>
         Some(NAME)
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -455,11 +453,11 @@ impl<'element, 'header> Render<'element, 'header>
     }
 }
 
-impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjCarousel {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjCarousel {
     fn renderer(
-        &'element self,
-        context: &'header RenderContext<'header>,
-    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         let id = context.generator.next_id();
         Box::new(Renderer::new(context, self, MjCarouselExtra { id }))
     }

--- a/packages/mrml-core/src/mj_carousel/render.rs
+++ b/packages/mrml-core/src/mj_carousel/render.rs
@@ -2,10 +2,6 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::{MjCarousel, MjCarouselChild, NAME};
-use crate::helper::condition::{
-    END_CONDITIONAL_TAG, END_NEGATION_CONDITIONAL_TAG, START_MSO_CONDITIONAL_TAG,
-    START_MSO_NEGATION_CONDITIONAL_TAG,
-};
 use crate::helper::size::{Pixel, Size};
 use crate::helper::style::Style;
 use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
@@ -228,9 +224,9 @@ impl<'e, 'h> MjCarouselRender<'e, 'h> {
                 .maybe_add_extra_attribute("tb-border-radius", self.attribute("tb-border-radius"));
             renderer.set_container_width(self.container_width.clone());
 
-            buf.push_str(START_MSO_CONDITIONAL_TAG);
+            buf.start_mso_conditional_tag();
             renderer.render(opts, buf)?;
-            buf.push_str(END_CONDITIONAL_TAG);
+            buf.end_conditional_tag();
         }
         Ok(())
     }
@@ -446,7 +442,7 @@ impl<'e, 'h> Render<'e, 'h> for MjCarouselRender<'e, 'h> {
             .add_class(format!("mj-carousel-{}-content", self.id));
         let div = Tag::div().add_class("mj-carousel");
 
-        buf.push_str(START_MSO_NEGATION_CONDITIONAL_TAG);
+        buf.start_mso_negation_conditional_tag();
         div.render_open(buf);
         self.render_radios(opts, buf)?;
         inner_div.render_open(buf);
@@ -454,7 +450,7 @@ impl<'e, 'h> Render<'e, 'h> for MjCarouselRender<'e, 'h> {
         self.render_carousel(opts, buf)?;
         inner_div.render_close(buf);
         div.render_close(buf);
-        buf.push_str(END_NEGATION_CONDITIONAL_TAG);
+        buf.end_negation_conditional_tag();
         self.render_fallback(opts, buf)?;
 
         Ok(())

--- a/packages/mrml-core/src/mj_carousel/render.rs
+++ b/packages/mrml-core/src/mj_carousel/render.rs
@@ -49,7 +49,7 @@ impl<'e, 'h> MjCarouselRender<'e, 'h> {
         }
     }
 
-    fn set_style_carousel_div(&self, tag: Tag) -> Tag {
+    fn set_style_carousel_div<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "table")
             .add_style("width", "100%")
             .add_style("table-layout", "fixed")
@@ -57,29 +57,29 @@ impl<'e, 'h> MjCarouselRender<'e, 'h> {
             .add_style("font-size", "0px")
     }
 
-    fn set_style_carousel_table(&self, tag: Tag) -> Tag {
+    fn set_style_carousel_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("caption-side", "top")
             .add_style("display", "table-caption")
             .add_style("table-layout", "fixed")
             .add_style("width", "100%")
     }
 
-    fn set_style_images_td(&self, tag: Tag) -> Tag {
+    fn set_style_images_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("padding", "0px")
     }
 
-    fn set_style_controls_div(&self, tag: Tag) -> Tag {
+    fn set_style_controls_div<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "none")
             .add_style("mso-hide", "all")
     }
 
-    fn set_style_controls_img(&self, tag: Tag) -> Tag {
+    fn set_style_controls_img<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "block")
             .maybe_add_style("width", self.attribute("icon-width"))
             .add_style("height", "auto")
     }
 
-    fn set_style_controls_td(&self, tag: Tag) -> Tag {
+    fn set_style_controls_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("font-size", "0px")
             .add_style("display", "none")
             .add_style("mso-hide", "all")

--- a/packages/mrml-core/src/mj_carousel/render.rs
+++ b/packages/mrml-core/src/mj_carousel/render.rs
@@ -391,7 +391,7 @@ impl<'e, 'h> MjCarouselRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjCarouselRender<'e, 'h> {
-    fn default_attribute(&self, name: &str) -> Option<&str> {
+    fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "align" => Some("center"),
             "border-radius" => Some("6px"),

--- a/packages/mrml-core/src/mj_carousel/render.rs
+++ b/packages/mrml-core/src/mj_carousel/render.rs
@@ -20,7 +20,6 @@ fn repeat(count: usize, value: &str) -> String {
 }
 
 struct MjCarouselExtra {
-    container_width: Option<Pixel>,
     siblings: usize,
     raw_siblings: usize,
     id: String,
@@ -34,7 +33,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjCarousel, MjCarouselExtra>
         } else {
             self.attribute_as_pixel("tb-width")
                 .or_else(|| {
-                    self.extra.container_width.as_ref().map(|width| {
+                    self.container_width.as_ref().map(|width| {
                         let value = width.value() / (count as f32);
                         if value < 110.0 {
                             Pixel::new(value)
@@ -170,7 +169,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjCarousel, MjCarouselExtra>
             renderer
                 .maybe_add_extra_attribute("tb-border-radius", self.attribute("tb-border-radius"));
             renderer.set_index(index);
-            renderer.set_container_width(self.extra.container_width.clone());
+            renderer.set_container_width(self.container_width.clone());
             renderer.render(cursor)?;
         }
 
@@ -224,7 +223,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjCarousel, MjCarouselExtra>
             renderer.maybe_add_extra_attribute("tb-border", self.attribute("tb-border"));
             renderer
                 .maybe_add_extra_attribute("tb-border-radius", self.attribute("tb-border-radius"));
-            renderer.set_container_width(self.extra.container_width.clone());
+            renderer.set_container_width(self.container_width.clone());
 
             cursor.buffer.start_mso_conditional_tag();
             renderer.render(cursor)?;
@@ -417,14 +416,13 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn get_width(&self) -> Option<Size> {
-        self.extra
-            .container_width
+        self.container_width
             .as_ref()
             .map(|w| Size::Pixel(w.clone()))
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn set_siblings(&mut self, value: usize) {
@@ -469,7 +467,6 @@ impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjCaro
             context,
             self,
             MjCarouselExtra {
-                container_width: None,
                 siblings: 1,
                 raw_siblings: 0,
                 id,

--- a/packages/mrml-core/src/mj_carousel/render.rs
+++ b/packages/mrml-core/src/mj_carousel/render.rs
@@ -89,18 +89,10 @@ impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
         for (index, child) in self.element.children.iter().enumerate() {
             let mut renderer = child.renderer(self.context());
             renderer.add_extra_attribute("carousel-id", &self.extra.id);
-            renderer.maybe_add_extra_attribute(
-                "border-radius",
-                self.attribute("border-radius").map(|v| v.to_owned()),
-            );
-            renderer.maybe_add_extra_attribute(
-                "tb-border",
-                self.attribute("tb-border").map(|v| v.to_owned()),
-            );
-            renderer.maybe_add_extra_attribute(
-                "tb-border-radius",
-                self.attribute("tb-border-radius").map(|v| v.to_owned()),
-            );
+            renderer.maybe_add_extra_attribute("border-radius", self.attribute("border-radius"));
+            renderer.maybe_add_extra_attribute("tb-border", self.attribute("tb-border"));
+            renderer
+                .maybe_add_extra_attribute("tb-border-radius", self.attribute("tb-border-radius"));
             renderer.set_index(index);
             renderer.render_fragment("radio", cursor)?;
         }
@@ -114,17 +106,12 @@ impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
             for (index, child) in self.element.children.iter().enumerate() {
                 let mut renderer = child.renderer(self.context());
                 renderer.add_extra_attribute("carousel-id", &self.extra.id);
-                renderer.maybe_add_extra_attribute(
-                    "border-radius",
-                    self.attribute("border-radius").map(|v| v.to_owned()),
-                );
-                renderer.maybe_add_extra_attribute(
-                    "tb-border",
-                    self.attribute("tb-border").map(|v| v.to_owned()),
-                );
+                renderer
+                    .maybe_add_extra_attribute("border-radius", self.attribute("border-radius"));
+                renderer.maybe_add_extra_attribute("tb-border", self.attribute("tb-border"));
                 renderer.maybe_add_extra_attribute(
                     "tb-border-radius",
-                    self.attribute("tb-border-radius").map(|v| v.to_owned()),
+                    self.attribute("tb-border-radius"),
                 );
                 renderer.set_index(index);
                 renderer.set_container_width(Some(width.clone()));
@@ -179,18 +166,10 @@ impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
         for (index, child) in self.element.children.iter().enumerate() {
             let mut renderer = child.renderer(self.context());
             renderer.add_extra_attribute("carousel-id", &self.extra.id);
-            renderer.maybe_add_extra_attribute(
-                "border-radius",
-                self.attribute("border-radius").map(|v| v.to_owned()),
-            );
-            renderer.maybe_add_extra_attribute(
-                "tb-border",
-                self.attribute("tb-border").map(|v| v.to_owned()),
-            );
-            renderer.maybe_add_extra_attribute(
-                "tb-border-radius",
-                self.attribute("tb-border-radius").map(|v| v.to_owned()),
-            );
+            renderer.maybe_add_extra_attribute("border-radius", self.attribute("border-radius"));
+            renderer.maybe_add_extra_attribute("tb-border", self.attribute("tb-border"));
+            renderer
+                .maybe_add_extra_attribute("tb-border-radius", self.attribute("tb-border-radius"));
             renderer.set_index(index);
             renderer.set_container_width(self.container_width.clone());
             renderer.render(cursor)?;
@@ -242,18 +221,10 @@ impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
         {
             let mut renderer = child.renderer(self.context());
             renderer.add_extra_attribute("carousel-id", &self.extra.id);
-            renderer.maybe_add_extra_attribute(
-                "border-radius",
-                self.attribute("border-radius").map(|v| v.to_owned()),
-            );
-            renderer.maybe_add_extra_attribute(
-                "tb-border",
-                self.attribute("tb-border").map(|v| v.to_owned()),
-            );
-            renderer.maybe_add_extra_attribute(
-                "tb-border-radius",
-                self.attribute("tb-border-radius").map(|v| v.to_owned()),
-            );
+            renderer.maybe_add_extra_attribute("border-radius", self.attribute("border-radius"));
+            renderer.maybe_add_extra_attribute("tb-border", self.attribute("tb-border"));
+            renderer
+                .maybe_add_extra_attribute("tb-border-radius", self.attribute("tb-border-radius"));
             renderer.set_container_width(self.container_width.clone());
 
             cursor.buffer.start_mso_conditional_tag();

--- a/packages/mrml-core/src/mj_carousel/render.rs
+++ b/packages/mrml-core/src/mj_carousel/render.rs
@@ -44,7 +44,7 @@ impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
         }
     }
 
-    fn set_style_carousel_div<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_carousel_div<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         tag.add_style("display", "table")
             .add_style("width", "100%")
             .add_style("table-layout", "fixed")
@@ -52,29 +52,33 @@ impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
             .add_style("font-size", "0px")
     }
 
-    fn set_style_carousel_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_carousel_table<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         tag.add_style("caption-side", "top")
             .add_style("display", "table-caption")
             .add_style("table-layout", "fixed")
             .add_style("width", "100%")
     }
 
-    fn set_style_images_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_images_td<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         tag.add_style("padding", "0px")
     }
 
-    fn set_style_controls_div<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_controls_div<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         tag.add_style("display", "none")
             .add_style("mso-hide", "all")
     }
 
-    fn set_style_controls_img<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_controls_img<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.add_style("display", "block")
             .maybe_add_style("width", self.attribute("icon-width"))
             .add_style("height", "auto")
     }
 
-    fn set_style_controls_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_controls_td<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         tag.add_style("font-size", "0px")
             .add_style("display", "none")
             .add_style("mso-hide", "all")
@@ -85,10 +89,18 @@ impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
         for (index, child) in self.element.children.iter().enumerate() {
             let mut renderer = child.renderer(self.context());
             renderer.add_extra_attribute("carousel-id", &self.extra.id);
-            renderer.maybe_add_extra_attribute("border-radius", self.attribute("border-radius"));
-            renderer.maybe_add_extra_attribute("tb-border", self.attribute("tb-border"));
-            renderer
-                .maybe_add_extra_attribute("tb-border-radius", self.attribute("tb-border-radius"));
+            renderer.maybe_add_extra_attribute(
+                "border-radius",
+                self.attribute("border-radius").map(|v| v.to_owned()),
+            );
+            renderer.maybe_add_extra_attribute(
+                "tb-border",
+                self.attribute("tb-border").map(|v| v.to_owned()),
+            );
+            renderer.maybe_add_extra_attribute(
+                "tb-border-radius",
+                self.attribute("tb-border-radius").map(|v| v.to_owned()),
+            );
             renderer.set_index(index);
             renderer.render_fragment("radio", cursor)?;
         }
@@ -102,12 +114,17 @@ impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
             for (index, child) in self.element.children.iter().enumerate() {
                 let mut renderer = child.renderer(self.context());
                 renderer.add_extra_attribute("carousel-id", &self.extra.id);
-                renderer
-                    .maybe_add_extra_attribute("border-radius", self.attribute("border-radius"));
-                renderer.maybe_add_extra_attribute("tb-border", self.attribute("tb-border"));
+                renderer.maybe_add_extra_attribute(
+                    "border-radius",
+                    self.attribute("border-radius").map(|v| v.to_owned()),
+                );
+                renderer.maybe_add_extra_attribute(
+                    "tb-border",
+                    self.attribute("tb-border").map(|v| v.to_owned()),
+                );
                 renderer.maybe_add_extra_attribute(
                     "tb-border-radius",
-                    self.attribute("tb-border-radius"),
+                    self.attribute("tb-border-radius").map(|v| v.to_owned()),
                 );
                 renderer.set_index(index);
                 renderer.set_container_width(Some(width.clone()));
@@ -162,10 +179,18 @@ impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
         for (index, child) in self.element.children.iter().enumerate() {
             let mut renderer = child.renderer(self.context());
             renderer.add_extra_attribute("carousel-id", &self.extra.id);
-            renderer.maybe_add_extra_attribute("border-radius", self.attribute("border-radius"));
-            renderer.maybe_add_extra_attribute("tb-border", self.attribute("tb-border"));
-            renderer
-                .maybe_add_extra_attribute("tb-border-radius", self.attribute("tb-border-radius"));
+            renderer.maybe_add_extra_attribute(
+                "border-radius",
+                self.attribute("border-radius").map(|v| v.to_owned()),
+            );
+            renderer.maybe_add_extra_attribute(
+                "tb-border",
+                self.attribute("tb-border").map(|v| v.to_owned()),
+            );
+            renderer.maybe_add_extra_attribute(
+                "tb-border-radius",
+                self.attribute("tb-border-radius").map(|v| v.to_owned()),
+            );
             renderer.set_index(index);
             renderer.set_container_width(self.container_width.clone());
             renderer.render(cursor)?;
@@ -191,13 +216,13 @@ impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
 
         self.render_controls(
             "previous",
-            self.attribute("left-icon").unwrap().as_str(),
+            self.attribute("left-icon").unwrap(),
             &mut cursor.buffer,
         );
         self.render_images(cursor)?;
         self.render_controls(
             "next",
-            self.attribute("right-icon").unwrap().as_str(),
+            self.attribute("right-icon").unwrap(),
             &mut cursor.buffer,
         );
 
@@ -217,10 +242,18 @@ impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
         {
             let mut renderer = child.renderer(self.context());
             renderer.add_extra_attribute("carousel-id", &self.extra.id);
-            renderer.maybe_add_extra_attribute("border-radius", self.attribute("border-radius"));
-            renderer.maybe_add_extra_attribute("tb-border", self.attribute("tb-border"));
-            renderer
-                .maybe_add_extra_attribute("tb-border-radius", self.attribute("tb-border-radius"));
+            renderer.maybe_add_extra_attribute(
+                "border-radius",
+                self.attribute("border-radius").map(|v| v.to_owned()),
+            );
+            renderer.maybe_add_extra_attribute(
+                "tb-border",
+                self.attribute("tb-border").map(|v| v.to_owned()),
+            );
+            renderer.maybe_add_extra_attribute(
+                "tb-border-radius",
+                self.attribute("tb-border-radius").map(|v| v.to_owned()),
+            );
             renderer.set_container_width(self.container_width.clone());
 
             cursor.buffer.start_mso_conditional_tag();

--- a/packages/mrml-core/src/mj_carousel_image/render.rs
+++ b/packages/mrml-core/src/mj_carousel_image/render.rs
@@ -167,24 +167,19 @@ impl<'e, 'h> Render<'e, 'h> for MjCarouselImageRender<'e, 'h> {
         self.context
     }
 
-    fn render_fragment(
-        &self,
-        name: &str,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_fragment(&self, name: &str, cursor: &mut RenderCursor) -> Result<(), Error> {
         match name {
-            "main" => self.render(header, buf),
+            "main" => self.render(cursor),
             "radio" => {
-                self.render_radio(buf);
+                self.render_radio(&mut cursor.buffer);
                 Ok(())
             }
-            "thumbnail" => self.render_thumbnail(buf),
+            "thumbnail" => self.render_thumbnail(&mut cursor.buffer),
             _ => Err(Error::UnknownFragment(name.to_string())),
         }
     }
 
-    fn render(&self, _header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let img = self
             .set_style_images_img(Tag::new("img"))
             .add_attribute("border", "0")
@@ -209,19 +204,19 @@ impl<'e, 'h> Render<'e, 'h> for MjCarouselImageRender<'e, 'h> {
             .add_class(format!("mj-carousel-image-{}", self.index + 1))
             .maybe_add_class(self.attribute("css-class"));
 
-        div.render_open(buf);
+        div.render_open(&mut cursor.buffer);
         if let Some(href) = self.attribute("href") {
             let link = Tag::new("a")
                 .add_attribute("href", href)
                 .maybe_add_attribute("rel", self.attribute("rel"))
                 .add_attribute("target", "_blank");
-            link.render_open(buf);
-            img.render_closed(buf);
-            link.render_close(buf);
+            link.render_open(&mut cursor.buffer);
+            img.render_closed(&mut cursor.buffer);
+            link.render_close(&mut cursor.buffer);
         } else {
-            img.render_closed(buf);
+            img.render_closed(&mut cursor.buffer);
         }
-        div.render_close(buf);
+        div.render_close(&mut cursor.buffer);
 
         Ok(())
     }

--- a/packages/mrml-core/src/mj_carousel_image/render.rs
+++ b/packages/mrml-core/src/mj_carousel_image/render.rs
@@ -132,7 +132,7 @@ impl<'e, 'h> MjCarouselImageRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjCarouselImageRender<'e, 'h> {
-    fn default_attribute(&self, key: &str) -> Option<&str> {
+    fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "target" => Some("_blank"),
             _ => None,

--- a/packages/mrml-core/src/mj_carousel_image/render.rs
+++ b/packages/mrml-core/src/mj_carousel_image/render.rs
@@ -131,7 +131,7 @@ impl<'e, 'h> MjCarouselImageRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjCarouselImageRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjCarouselImageRender<'e, 'h> {
     fn default_attribute(&self, key: &str) -> Option<&str> {
         match key {
             "target" => Some("_blank"),
@@ -143,12 +143,12 @@ impl<'e, 'h> Render<'h> for MjCarouselImageRender<'e, 'h> {
         self.extra.insert(key.to_string(), value.to_string());
     }
 
-    fn extra_attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.extra)
+    fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
+        self.extra.get(key).map(|v| v.as_str())
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -215,7 +215,7 @@ impl<'e, 'h> Render<'h> for MjCarouselImageRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjCarouselImage {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjCarouselImageRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_carousel_image/render.rs
+++ b/packages/mrml-core/src/mj_carousel_image/render.rs
@@ -3,11 +3,11 @@ use crate::helper::size::Pixel;
 use crate::prelude::hash::Map;
 use crate::prelude::render::*;
 
-struct MjCarouselImageExtra {
-    attributes: Map<String, String>,
+struct MjCarouselImageExtra<'a> {
+    attributes: Map<&'a str, &'a str>,
 }
 
-impl<'root> Renderer<'root, MjCarouselImage, MjCarouselImageExtra> {
+impl<'root> Renderer<'root, MjCarouselImage, MjCarouselImageExtra<'root>> {
     fn set_style_images_img<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
     where
         'root: 'a,
@@ -142,7 +142,7 @@ impl<'root> Renderer<'root, MjCarouselImage, MjCarouselImageExtra> {
     }
 }
 
-impl<'root> Render<'root> for Renderer<'root, MjCarouselImage, MjCarouselImageExtra> {
+impl<'root> Render<'root> for Renderer<'root, MjCarouselImage, MjCarouselImageExtra<'root>> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "target" => Some("_blank"),
@@ -150,14 +150,12 @@ impl<'root> Render<'root> for Renderer<'root, MjCarouselImage, MjCarouselImageEx
         }
     }
 
-    fn add_extra_attribute(&mut self, key: &str, value: &str) {
-        self.extra
-            .attributes
-            .insert(key.to_string(), value.to_string());
+    fn add_extra_attribute(&mut self, key: &'root str, value: &'root str) {
+        self.extra.attributes.insert(key, value);
     }
 
-    fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
-        self.extra.attributes.get(key).map(|v| v.as_str())
+    fn raw_extra_attribute(&self, key: &str) -> Option<&'root str> {
+        self.extra.attributes.get(key).copied()
     }
 
     fn raw_attribute(&self, key: &str) -> Option<&'root str> {

--- a/packages/mrml-core/src/mj_carousel_image/render.rs
+++ b/packages/mrml-core/src/mj_carousel_image/render.rs
@@ -4,7 +4,7 @@ use crate::prelude::hash::Map;
 use crate::prelude::render::*;
 
 struct MjCarouselImageRender<'e, 'h> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e MjCarouselImage,
     extra: Map<String, String>,
     container_width: Option<Pixel>,
@@ -163,34 +163,28 @@ impl<'e, 'h> Render<'e, 'h> for MjCarouselImageRender<'e, 'h> {
         self.index = index;
     }
 
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        self.context
     }
 
     fn render_fragment(
         &self,
         name: &str,
-        opts: &RenderOptions,
         header: &mut VariableHeader,
         buf: &mut RenderBuffer,
     ) -> Result<(), Error> {
         match name {
-            "main" => self.render(opts, header, buf),
+            "main" => self.render(header, buf),
             "radio" => {
                 self.render_radio(buf);
                 Ok(())
-            },
+            }
             "thumbnail" => self.render_thumbnail(buf),
             _ => Err(Error::UnknownFragment(name.to_string())),
         }
     }
 
-    fn render(
-        &self,
-        _opts: &RenderOptions,
-        _header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render(&self, _header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
         let img = self
             .set_style_images_img(Tag::new("img"))
             .add_attribute("border", "0")
@@ -234,10 +228,10 @@ impl<'e, 'h> Render<'e, 'h> for MjCarouselImageRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjCarouselImage {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjCarouselImageRender::<'e, 'h> {
             element: self,
-            header,
+            context,
             extra: Map::new(),
             container_width: None,
             index: 0,

--- a/packages/mrml-core/src/mj_carousel_image/render.rs
+++ b/packages/mrml-core/src/mj_carousel_image/render.rs
@@ -5,7 +5,6 @@ use crate::prelude::render::*;
 
 struct MjCarouselImageExtra {
     attributes: Map<String, String>,
-    index: usize,
 }
 
 impl<'element, 'header> Renderer<'element, 'header, MjCarouselImage, MjCarouselImageExtra> {
@@ -52,11 +51,11 @@ impl<'element, 'header> Renderer<'element, 'header, MjCarouselImage, MjCarouselI
                 self.extra
                     .attributes
                     .get("carousel-id")
-                    .map(|id| format!("mj-carousel-{}-radio-{}", id, self.extra.index + 1)),
+                    .map(|id| format!("mj-carousel-{}-radio-{}", id, self.index + 1)),
             )
             .maybe_add_attribute(
                 "checked",
-                if self.extra.index == 0 {
+                if self.index == 0 {
                     Some("checked")
                 } else {
                     None
@@ -75,7 +74,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjCarouselImage, MjCarouselI
                 self.extra
                     .attributes
                     .get("carousel-id")
-                    .map(|id| format!("mj-carousel-{}-radio-{}", id, self.extra.index + 1)),
+                    .map(|id| format!("mj-carousel-{}-radio-{}", id, self.index + 1)),
             )
             .render_closed(buf);
     }
@@ -100,11 +99,11 @@ impl<'element, 'header> Renderer<'element, 'header, MjCarouselImage, MjCarouselI
             self.extra
                 .attributes
                 .get("carousel-id")
-                .map(|id| format!("mj-carousel-{}-radio-{}", id, self.extra.index + 1)),
+                .map(|id| format!("mj-carousel-{}-radio-{}", id, self.index + 1)),
         );
         let link = self
             .set_style_thumbnails_a(Tag::new("a"))
-            .add_attribute("href", format!("#{}", self.extra.index + 1))
+            .add_attribute("href", format!("#{}", self.index + 1))
             .maybe_add_attribute("target", self.attribute("target"))
             .add_class("mj-carousel-thumbnail")
             .maybe_add_class(
@@ -117,7 +116,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjCarouselImage, MjCarouselI
                 self.extra
                     .attributes
                     .get("carousel-id")
-                    .map(|id| format!("mj-carousel-{}-thumbnail-{}", id, self.extra.index + 1)),
+                    .map(|id| format!("mj-carousel-{}-thumbnail-{}", id, self.index + 1)),
             )
             .maybe_add_suffixed_class(self.attribute("css-class"), "thumbnail")
             .maybe_add_style(
@@ -168,7 +167,7 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_index(&mut self, index: usize) {
-        self.extra.index = index;
+        self.index = index;
     }
 
     fn context(&self) -> &'header RenderContext<'header> {
@@ -200,7 +199,7 @@ impl<'element, 'header> Render<'element, 'header>
                     .as_ref()
                     .map(|width| width.value().to_string()),
             );
-        let div = if self.extra.index == 0 {
+        let div = if self.index == 0 {
             Tag::div()
         } else {
             Tag::div()
@@ -209,7 +208,7 @@ impl<'element, 'header> Render<'element, 'header>
         };
         let div = div
             .add_class("mj-carousel-image")
-            .add_class(format!("mj-carousel-image-{}", self.extra.index + 1))
+            .add_class(format!("mj-carousel-image-{}", self.index + 1))
             .maybe_add_class(self.attribute("css-class"));
 
         div.render_open(&mut cursor.buffer);
@@ -240,7 +239,6 @@ impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjCaro
             self,
             MjCarouselImageExtra {
                 attributes: Map::new(),
-                index: 0,
             },
         ))
     }

--- a/packages/mrml-core/src/mj_carousel_image/render.rs
+++ b/packages/mrml-core/src/mj_carousel_image/render.rs
@@ -15,7 +15,7 @@ struct MjCarouselImageRender<'e, 'h> {
 }
 
 impl<'e, 'h> MjCarouselImageRender<'e, 'h> {
-    fn set_style_images_img(&self, tag: Tag) -> Tag {
+    fn set_style_images_img<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("border-radius", self.attribute("border-radius"))
             .add_style("display", "block")
             .maybe_add_style(
@@ -26,12 +26,12 @@ impl<'e, 'h> MjCarouselImageRender<'e, 'h> {
             .add_style("height", "auto")
     }
 
-    fn set_style_radio_input(&self, tag: Tag) -> Tag {
+    fn set_style_radio_input<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "none")
             .add_style("mso-hide", "all")
     }
 
-    fn set_style_thumbnails_a(&self, tag: Tag) -> Tag {
+    fn set_style_thumbnails_a<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("border", self.attribute("tb-border"))
             .maybe_add_style("border-radius", self.attribute("tb-border-radius"))
             .add_style("display", "inline-block")
@@ -39,7 +39,7 @@ impl<'e, 'h> MjCarouselImageRender<'e, 'h> {
             .maybe_add_style("width", self.attribute("tb-width"))
     }
 
-    fn set_style_thumbnails_img(&self, tag: Tag) -> Tag {
+    fn set_style_thumbnails_img<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "block")
             .add_style("width", "100%")
             .add_style("height", "auto")

--- a/packages/mrml-core/src/mj_carousel_image/render.rs
+++ b/packages/mrml-core/src/mj_carousel_image/render.rs
@@ -8,7 +8,11 @@ struct MjCarouselImageExtra {
 }
 
 impl<'root> Renderer<'root, MjCarouselImage, MjCarouselImageExtra> {
-    fn set_style_images_img<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_images_img<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.maybe_add_style("border-radius", self.attribute("border-radius"))
             .add_style("display", "block")
             .maybe_add_style(
@@ -19,12 +23,16 @@ impl<'root> Renderer<'root, MjCarouselImage, MjCarouselImageExtra> {
             .add_style("height", "auto")
     }
 
-    fn set_style_radio_input<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_radio_input<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         tag.add_style("display", "none")
             .add_style("mso-hide", "all")
     }
 
-    fn set_style_thumbnails_a<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_thumbnails_a<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.maybe_add_style("border", self.attribute("tb-border"))
             .maybe_add_style("border-radius", self.attribute("tb-border-radius"))
             .add_style("display", "inline-block")
@@ -32,7 +40,7 @@ impl<'root> Renderer<'root, MjCarouselImage, MjCarouselImageExtra> {
             .maybe_add_style("width", self.attribute("tb-width"))
     }
 
-    fn set_style_thumbnails_img<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_thumbnails_img<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         tag.add_style("display", "block")
             .add_style("width", "100%")
             .add_style("height", "auto")

--- a/packages/mrml-core/src/mj_carousel_image/render.rs
+++ b/packages/mrml-core/src/mj_carousel_image/render.rs
@@ -5,7 +5,6 @@ use crate::prelude::render::*;
 
 struct MjCarouselImageExtra {
     attributes: Map<String, String>,
-    container_width: Option<Pixel>,
     index: usize,
 }
 
@@ -15,10 +14,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjCarouselImage, MjCarouselI
             .add_style("display", "block")
             .maybe_add_style(
                 "width",
-                self.extra
-                    .container_width
-                    .as_ref()
-                    .map(|value| value.to_string()),
+                self.container_width.as_ref().map(|value| value.to_string()),
             )
             .add_style("max-width", "100%")
             .add_style("height", "auto")
@@ -95,8 +91,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjCarouselImage, MjCarouselI
             .maybe_add_attribute("alt", self.attribute("alt"))
             .maybe_add_attribute(
                 "width",
-                self.extra
-                    .container_width
+                self.container_width
                     .as_ref()
                     .map(|item| item.value().to_string()),
             );
@@ -127,10 +122,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjCarouselImage, MjCarouselI
             .maybe_add_suffixed_class(self.attribute("css-class"), "thumbnail")
             .maybe_add_style(
                 "width",
-                self.extra
-                    .container_width
-                    .as_ref()
-                    .map(|item| item.to_string()),
+                self.container_width.as_ref().map(|item| item.to_string()),
             );
 
         link.render_open(buf);
@@ -172,7 +164,7 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn set_index(&mut self, index: usize) {
@@ -204,8 +196,7 @@ impl<'element, 'header> Render<'element, 'header>
             .maybe_add_attribute("title", self.attribute("title"))
             .maybe_add_attribute(
                 "width",
-                self.extra
-                    .container_width
+                self.container_width
                     .as_ref()
                     .map(|width| width.value().to_string()),
             );
@@ -249,7 +240,6 @@ impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjCaro
             self,
             MjCarouselImageExtra {
                 attributes: Map::new(),
-                container_width: None,
                 index: 0,
             },
         ))

--- a/packages/mrml-core/src/mj_carousel_image/render.rs
+++ b/packages/mrml-core/src/mj_carousel_image/render.rs
@@ -7,7 +7,7 @@ struct MjCarouselImageExtra {
     attributes: Map<String, String>,
 }
 
-impl<'element, 'header> Renderer<'element, 'header, MjCarouselImage, MjCarouselImageExtra> {
+impl<'root> Renderer<'root, MjCarouselImage, MjCarouselImageExtra> {
     fn set_style_images_img<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("border-radius", self.attribute("border-radius"))
             .add_style("display", "block")
@@ -134,9 +134,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjCarouselImage, MjCarouselI
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjCarouselImage, MjCarouselImageExtra>
-{
+impl<'root> Render<'root> for Renderer<'root, MjCarouselImage, MjCarouselImageExtra> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "target" => Some("_blank"),
@@ -154,7 +152,7 @@ impl<'element, 'header> Render<'element, 'header>
         self.extra.attributes.get(key).map(|v| v.as_str())
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -170,7 +168,7 @@ impl<'element, 'header> Render<'element, 'header>
         self.index = index;
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -229,11 +227,11 @@ impl<'element, 'header> Render<'element, 'header>
     }
 }
 
-impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjCarouselImage {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjCarouselImage {
     fn renderer(
-        &'element self,
-        context: &'header RenderContext<'header>,
-    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(
             context,
             self,

--- a/packages/mrml-core/src/mj_carousel_image/render.rs
+++ b/packages/mrml-core/src/mj_carousel_image/render.rs
@@ -3,21 +3,22 @@ use crate::helper::size::Pixel;
 use crate::prelude::hash::Map;
 use crate::prelude::render::*;
 
-struct MjCarouselImageRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e MjCarouselImage,
-    extra: Map<String, String>,
+struct MjCarouselImageExtra {
+    attributes: Map<String, String>,
     container_width: Option<Pixel>,
     index: usize,
 }
 
-impl<'e, 'h> MjCarouselImageRender<'e, 'h> {
+impl<'element, 'header> Renderer<'element, 'header, MjCarouselImage, MjCarouselImageExtra> {
     fn set_style_images_img<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("border-radius", self.attribute("border-radius"))
             .add_style("display", "block")
             .maybe_add_style(
                 "width",
-                self.container_width.as_ref().map(|value| value.to_string()),
+                self.extra
+                    .container_width
+                    .as_ref()
+                    .map(|value| value.to_string()),
             )
             .add_style("max-width", "100%")
             .add_style("height", "auto")
@@ -47,17 +48,19 @@ impl<'e, 'h> MjCarouselImageRender<'e, 'h> {
             .add_class("mj-carousel-radio")
             .maybe_add_class(
                 self.extra
+                    .attributes
                     .get("carousel-id")
                     .map(|id| format!("mj-carousel-{id}-radio")),
             )
             .maybe_add_class(
                 self.extra
+                    .attributes
                     .get("carousel-id")
-                    .map(|id| format!("mj-carousel-{}-radio-{}", id, self.index + 1)),
+                    .map(|id| format!("mj-carousel-{}-radio-{}", id, self.extra.index + 1)),
             )
             .maybe_add_attribute(
                 "checked",
-                if self.index == 0 {
+                if self.extra.index == 0 {
                     Some("checked")
                 } else {
                     None
@@ -67,14 +70,16 @@ impl<'e, 'h> MjCarouselImageRender<'e, 'h> {
             .maybe_add_attribute(
                 "name",
                 self.extra
+                    .attributes
                     .get("carousel-id")
                     .map(|id| format!("mj-carousel-radio-{id}")),
             )
             .maybe_add_attribute(
                 "id",
                 self.extra
+                    .attributes
                     .get("carousel-id")
-                    .map(|id| format!("mj-carousel-{}-radio-{}", id, self.index + 1)),
+                    .map(|id| format!("mj-carousel-{}-radio-{}", id, self.extra.index + 1)),
             )
             .render_closed(buf);
     }
@@ -90,35 +95,42 @@ impl<'e, 'h> MjCarouselImageRender<'e, 'h> {
             .maybe_add_attribute("alt", self.attribute("alt"))
             .maybe_add_attribute(
                 "width",
-                self.container_width
+                self.extra
+                    .container_width
                     .as_ref()
                     .map(|item| item.value().to_string()),
             );
         let label = Tag::new("label").maybe_add_attribute(
             "for",
             self.extra
+                .attributes
                 .get("carousel-id")
-                .map(|id| format!("mj-carousel-{}-radio-{}", id, self.index + 1)),
+                .map(|id| format!("mj-carousel-{}-radio-{}", id, self.extra.index + 1)),
         );
         let link = self
             .set_style_thumbnails_a(Tag::new("a"))
-            .add_attribute("href", format!("#{}", self.index + 1))
+            .add_attribute("href", format!("#{}", self.extra.index + 1))
             .maybe_add_attribute("target", self.attribute("target"))
             .add_class("mj-carousel-thumbnail")
             .maybe_add_class(
                 self.extra
+                    .attributes
                     .get("carousel-id")
                     .map(|id| format!("mj-carousel-{id}-thumbnail")),
             )
             .maybe_add_class(
                 self.extra
+                    .attributes
                     .get("carousel-id")
-                    .map(|id| format!("mj-carousel-{}-thumbnail-{}", id, self.index + 1)),
+                    .map(|id| format!("mj-carousel-{}-thumbnail-{}", id, self.extra.index + 1)),
             )
             .maybe_add_suffixed_class(self.attribute("css-class"), "thumbnail")
             .maybe_add_style(
                 "width",
-                self.container_width.as_ref().map(|item| item.to_string()),
+                self.extra
+                    .container_width
+                    .as_ref()
+                    .map(|item| item.to_string()),
             );
 
         link.render_open(buf);
@@ -131,7 +143,9 @@ impl<'e, 'h> MjCarouselImageRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'e, 'h> for MjCarouselImageRender<'e, 'h> {
+impl<'element, 'header> Render<'element, 'header>
+    for Renderer<'element, 'header, MjCarouselImage, MjCarouselImageExtra>
+{
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "target" => Some("_blank"),
@@ -140,14 +154,16 @@ impl<'e, 'h> Render<'e, 'h> for MjCarouselImageRender<'e, 'h> {
     }
 
     fn add_extra_attribute(&mut self, key: &str, value: &str) {
-        self.extra.insert(key.to_string(), value.to_string());
+        self.extra
+            .attributes
+            .insert(key.to_string(), value.to_string());
     }
 
     fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
-        self.extra.get(key).map(|v| v.as_str())
+        self.extra.attributes.get(key).map(|v| v.as_str())
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -156,14 +172,14 @@ impl<'e, 'h> Render<'e, 'h> for MjCarouselImageRender<'e, 'h> {
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.container_width = width;
+        self.extra.container_width = width;
     }
 
     fn set_index(&mut self, index: usize) {
-        self.index = index;
+        self.extra.index = index;
     }
 
-    fn context(&self) -> &'h RenderContext<'h> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
@@ -188,11 +204,12 @@ impl<'e, 'h> Render<'e, 'h> for MjCarouselImageRender<'e, 'h> {
             .maybe_add_attribute("title", self.attribute("title"))
             .maybe_add_attribute(
                 "width",
-                self.container_width
+                self.extra
+                    .container_width
                     .as_ref()
                     .map(|width| width.value().to_string()),
             );
-        let div = if self.index == 0 {
+        let div = if self.extra.index == 0 {
             Tag::div()
         } else {
             Tag::div()
@@ -201,7 +218,7 @@ impl<'e, 'h> Render<'e, 'h> for MjCarouselImageRender<'e, 'h> {
         };
         let div = div
             .add_class("mj-carousel-image")
-            .add_class(format!("mj-carousel-image-{}", self.index + 1))
+            .add_class(format!("mj-carousel-image-{}", self.extra.index + 1))
             .maybe_add_class(self.attribute("css-class"));
 
         div.render_open(&mut cursor.buffer);
@@ -222,14 +239,19 @@ impl<'e, 'h> Render<'e, 'h> for MjCarouselImageRender<'e, 'h> {
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjCarouselImage {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjCarouselImageRender::<'e, 'h> {
-            element: self,
+impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjCarouselImage {
+    fn renderer(
+        &'element self,
+        context: &'header RenderContext<'header>,
+    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        Box::new(Renderer::new(
             context,
-            extra: Map::new(),
-            container_width: None,
-            index: 0,
-        })
+            self,
+            MjCarouselImageExtra {
+                attributes: Map::new(),
+                container_width: None,
+                index: 0,
+            },
+        ))
     }
 }

--- a/packages/mrml-core/src/mj_carousel_image/render.rs
+++ b/packages/mrml-core/src/mj_carousel_image/render.rs
@@ -3,9 +3,8 @@ use std::rc::Rc;
 
 use super::{MjCarouselImage, NAME};
 use crate::helper::size::Pixel;
-use crate::helper::tag::Tag;
 use crate::prelude::hash::Map;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 struct MjCarouselImageRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,

--- a/packages/mrml-core/src/mj_column/render.rs
+++ b/packages/mrml-core/src/mj_column/render.rs
@@ -239,7 +239,7 @@ impl<'e, 'h> MjColumnRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjColumnRender<'e, 'h> {
-    fn default_attribute(&self, name: &str) -> Option<&str> {
+    fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "direction" => Some("ltr"),
             "vertical-align" => Some("top"),

--- a/packages/mrml-core/src/mj_column/render.rs
+++ b/packages/mrml-core/src/mj_column/render.rs
@@ -105,12 +105,12 @@ impl<'e, 'h> MjColumnRender<'e, 'h> {
         }
     }
 
-    fn set_style_td_outlook(&self, tag: Tag) -> Tag {
+    fn set_style_td_outlook<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("vertical-align", self.attribute("vertical-align"))
             .add_style("width", self.get_width_as_pixel())
     }
 
-    fn set_style_root_div(&self, tag: Tag) -> Tag {
+    fn set_style_root_div<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("font-size", "0px")
             .add_style("text-align", "left")
             .maybe_add_style("direction", self.attribute("direction"))
@@ -119,7 +119,7 @@ impl<'e, 'h> MjColumnRender<'e, 'h> {
             .maybe_add_style("width", self.get_mobile_width().map(|v| v.to_string()))
     }
 
-    fn set_style_table_gutter(&self, tag: Tag) -> Tag {
+    fn set_style_table_gutter<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style(
             "background-color",
             self.attribute("inner-background-color")
@@ -157,7 +157,7 @@ impl<'e, 'h> MjColumnRender<'e, 'h> {
         )
     }
 
-    fn set_style_table_simple(&self, tag: Tag) -> Tag {
+    fn set_style_table_simple<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("background-color", self.attribute("background-color"))
             .maybe_add_style("border", self.attribute("border"))
             .maybe_add_style("border-bottom", self.attribute("border-bottom"))
@@ -168,7 +168,7 @@ impl<'e, 'h> MjColumnRender<'e, 'h> {
             .maybe_add_style("vertical-align", self.attribute("vertical-align"))
     }
 
-    fn set_style_gutter_td(&self, tag: Tag) -> Tag {
+    fn set_style_gutter_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         self.set_style_table_simple(tag)
             .maybe_add_style("padding", self.attribute("padding"))
             .maybe_add_style("padding-top", self.attribute("padding-top"))
@@ -196,7 +196,7 @@ impl<'e, 'h> MjColumnRender<'e, 'h> {
         Ok(())
     }
 
-    fn set_style_table(&self, tag: Tag) -> Tag {
+    fn set_style_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         if self.has_gutter() {
             self.set_style_table_gutter(tag)
         } else {
@@ -302,7 +302,7 @@ impl<'e, 'h> Render<'e, 'h> for MjColumnRender<'e, 'h> {
         self.raw_siblings = value;
     }
 
-    fn set_style(&self, name: &str, tag: Tag) -> Tag {
+    fn set_style<'a>(&self, name: &str, tag: Tag<'a>) -> Tag<'a> {
         match name {
             "td-outlook" => self.set_style_td_outlook(tag),
             _ => tag,

--- a/packages/mrml-core/src/mj_column/render.rs
+++ b/packages/mrml-core/src/mj_column/render.rs
@@ -3,12 +3,11 @@ use crate::helper::size::{Pixel, Size};
 use crate::prelude::hash::Map;
 use crate::prelude::render::*;
 
-struct MjColumnExtra {
-    // TODO change lifetime
-    attributes: Map<String, String>,
+struct MjColumnExtra<'a> {
+    attributes: Map<&'a str, &'a str>,
 }
 
-impl<'root> Renderer<'root, MjColumn, MjColumnExtra> {
+impl<'root> Renderer<'root, MjColumn, MjColumnExtra<'root>> {
     fn current_width(&self) -> Option<Pixel> {
         let parent_width = self.container_width.as_ref()?;
         let non_raw_siblings = self.non_raw_siblings();
@@ -273,7 +272,7 @@ impl<'root> Renderer<'root, MjColumn, MjColumnExtra> {
     }
 }
 
-impl<'root> Render<'root> for Renderer<'root, MjColumn, MjColumnExtra> {
+impl<'root> Render<'root> for Renderer<'root, MjColumn, MjColumnExtra<'root>> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "direction" => Some("ltr"),
@@ -290,14 +289,12 @@ impl<'root> Render<'root> for Renderer<'root, MjColumn, MjColumnExtra> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
-    fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
-        self.extra.attributes.get(key).map(|v| v.as_str())
+    fn raw_extra_attribute(&self, key: &str) -> Option<&'root str> {
+        self.extra.attributes.get(key).copied()
     }
 
-    fn add_extra_attribute(&mut self, key: &str, value: &str) {
-        self.extra
-            .attributes
-            .insert(key.to_string(), value.to_string());
+    fn add_extra_attribute(&mut self, key: &'root str, value: &'root str) {
+        self.extra.attributes.insert(key, value);
     }
 
     fn tag(&self) -> Option<&str> {

--- a/packages/mrml-core/src/mj_column/render.rs
+++ b/packages/mrml-core/src/mj_column/render.rs
@@ -97,12 +97,20 @@ impl<'root> Renderer<'root, MjColumn, MjColumnExtra> {
         }
     }
 
-    fn set_style_td_outlook<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_td_outlook<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.maybe_add_style("vertical-align", self.attribute("vertical-align"))
             .add_style("width", self.get_width_as_pixel())
     }
 
-    fn set_style_root_div<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_root_div<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.add_style("font-size", "0px")
             .add_style("text-align", "left")
             .maybe_add_style("direction", self.attribute("direction"))
@@ -111,7 +119,11 @@ impl<'root> Renderer<'root, MjColumn, MjColumnExtra> {
             .maybe_add_style("width", self.get_mobile_width().map(|v| v.to_string()))
     }
 
-    fn set_style_table_gutter<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_table_gutter<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.maybe_add_style(
             "background-color",
             self.attribute("inner-background-color")
@@ -149,7 +161,11 @@ impl<'root> Renderer<'root, MjColumn, MjColumnExtra> {
         )
     }
 
-    fn set_style_table_simple<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_table_simple<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.maybe_add_style("background-color", self.attribute("background-color"))
             .maybe_add_style("border", self.attribute("border"))
             .maybe_add_style("border-bottom", self.attribute("border-bottom"))
@@ -160,7 +176,11 @@ impl<'root> Renderer<'root, MjColumn, MjColumnExtra> {
             .maybe_add_style("vertical-align", self.attribute("vertical-align"))
     }
 
-    fn set_style_gutter_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_gutter_td<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         self.set_style_table_simple(tag)
             .maybe_add_style("padding", self.attribute("padding"))
             .maybe_add_style("padding-top", self.attribute("padding-top"))
@@ -188,7 +208,11 @@ impl<'root> Renderer<'root, MjColumn, MjColumnExtra> {
         Ok(())
     }
 
-    fn set_style_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_table<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         if self.has_gutter() {
             self.set_style_table_gutter(tag)
         } else {
@@ -296,7 +320,11 @@ impl<'root> Render<'root> for Renderer<'root, MjColumn, MjColumnExtra> {
         self.raw_siblings = value;
     }
 
-    fn set_style<'a>(&self, name: &str, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style<'a, 't>(&'a self, name: &str, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         match name {
             "td-outlook" => self.set_style_td_outlook(tag),
             _ => tag,

--- a/packages/mrml-core/src/mj_column/render.rs
+++ b/packages/mrml-core/src/mj_column/render.rs
@@ -3,9 +3,8 @@ use std::rc::Rc;
 
 use super::{MjColumn, NAME};
 use crate::helper::size::{Pixel, Size};
-use crate::helper::tag::Tag;
 use crate::prelude::hash::Map;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 struct MjColumnRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,

--- a/packages/mrml-core/src/mj_column/render.rs
+++ b/packages/mrml-core/src/mj_column/render.rs
@@ -8,7 +8,7 @@ struct MjColumnExtra {
     attributes: Map<String, String>,
 }
 
-impl<'element, 'header> Renderer<'element, 'header, MjColumn, MjColumnExtra> {
+impl<'root> Renderer<'root, MjColumn, MjColumnExtra> {
     fn current_width(&self) -> Option<Pixel> {
         let parent_width = self.container_width.as_ref()?;
         let non_raw_siblings = self.non_raw_siblings();
@@ -249,9 +249,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjColumn, MjColumnExtra> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjColumn, MjColumnExtra>
-{
+impl<'root> Render<'root> for Renderer<'root, MjColumn, MjColumnExtra> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "direction" => Some("ltr"),
@@ -264,7 +262,7 @@ impl<'element, 'header> Render<'element, 'header>
         self.current_width().map(Size::Pixel)
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -282,7 +280,7 @@ impl<'element, 'header> Render<'element, 'header>
         Some(NAME)
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -326,11 +324,11 @@ impl<'element, 'header> Render<'element, 'header>
     }
 }
 
-impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjColumn {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjColumn {
     fn renderer(
-        &'element self,
-        context: &'header RenderContext<'header>,
-    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(
             context,
             self,

--- a/packages/mrml-core/src/mj_column/render.rs
+++ b/packages/mrml-core/src/mj_column/render.rs
@@ -6,14 +6,13 @@ use crate::prelude::render::*;
 struct MjColumnExtra {
     // TODO change lifetime
     attributes: Map<String, String>,
-    container_width: Option<Pixel>,
     siblings: usize,
     raw_siblings: usize,
 }
 
 impl<'element, 'header> Renderer<'element, 'header, MjColumn, MjColumnExtra> {
     fn current_width(&self) -> Option<Pixel> {
-        let parent_width = self.extra.container_width.as_ref()?;
+        let parent_width = self.container_width.as_ref()?;
         let non_raw_siblings = self.non_raw_siblings();
         let borders = self.get_border_horizontal();
         let paddings = self.get_padding_horizontal();
@@ -67,8 +66,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjColumn, MjColumnExtra> {
             if width.is_percent() {
                 Some(width)
             } else if width.is_pixel() {
-                self.extra
-                    .container_width
+                self.container_width
                     .as_ref()
                     .map(|w| Size::percent(width.value() / w.value()))
             } else {
@@ -88,7 +86,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjColumn, MjColumnExtra> {
     }
 
     fn get_width_as_pixel(&self) -> String {
-        if let Some(ref container_width) = self.extra.container_width {
+        if let Some(ref container_width) = self.container_width {
             let parsed_width = self.get_parsed_width();
             match parsed_width {
                 Size::Percent(value) => {
@@ -291,7 +289,7 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn set_siblings(&mut self, value: usize) {
@@ -340,7 +338,6 @@ impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjColu
             self,
             MjColumnExtra {
                 attributes: Map::new(),
-                container_width: None,
                 siblings: 1,
                 raw_siblings: 0,
             },

--- a/packages/mrml-core/src/mj_column/render.rs
+++ b/packages/mrml-core/src/mj_column/render.rs
@@ -6,8 +6,6 @@ use crate::prelude::render::*;
 struct MjColumnExtra {
     // TODO change lifetime
     attributes: Map<String, String>,
-    siblings: usize,
-    raw_siblings: usize,
 }
 
 impl<'element, 'header> Renderer<'element, 'header, MjColumn, MjColumnExtra> {
@@ -40,7 +38,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjColumn, MjColumnExtra> {
     }
 
     fn non_raw_siblings(&self) -> usize {
-        self.extra.siblings - self.extra.raw_siblings
+        self.siblings - self.raw_siblings
     }
 
     fn get_parsed_width(&self) -> Size {
@@ -293,11 +291,11 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_siblings(&mut self, value: usize) {
-        self.extra.siblings = value;
+        self.siblings = value;
     }
 
     fn set_raw_siblings(&mut self, value: usize) {
-        self.extra.raw_siblings = value;
+        self.raw_siblings = value;
     }
 
     fn set_style<'a>(&self, name: &str, tag: Tag<'a>) -> Tag<'a> {
@@ -338,8 +336,6 @@ impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjColu
             self,
             MjColumnExtra {
                 attributes: Map::new(),
-                siblings: 1,
-                raw_siblings: 0,
             },
         ))
     }

--- a/packages/mrml-core/src/mj_column/render.rs
+++ b/packages/mrml-core/src/mj_column/render.rs
@@ -238,7 +238,7 @@ impl<'e, 'h> MjColumnRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjColumnRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjColumnRender<'e, 'h> {
     fn default_attribute(&self, name: &str) -> Option<&str> {
         match name {
             "direction" => Some("ltr"),
@@ -251,12 +251,12 @@ impl<'e, 'h> Render<'h> for MjColumnRender<'e, 'h> {
         self.current_width().map(Size::Pixel)
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
-    fn extra_attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.extra)
+    fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
+        self.extra.get(key).map(|v| v.as_str())
     }
 
     fn add_extra_attribute(&mut self, key: &str, value: &str) {
@@ -310,7 +310,7 @@ impl<'e, 'h> Render<'h> for MjColumnRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjColumn {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjColumnRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_divider/render.rs
+++ b/packages/mrml-core/src/mj_divider/render.rs
@@ -2,11 +2,7 @@ use super::{MjDivider, NAME};
 use crate::helper::size::{Pixel, Size};
 use crate::prelude::render::*;
 
-struct MjDividerExtra {
-    container_width: Option<Pixel>,
-}
-
-impl<'element, 'header> Renderer<'element, 'header, MjDivider, MjDividerExtra> {
+impl<'element, 'header> Renderer<'element, 'header, MjDivider, ()> {
     fn set_style_p_without_width<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style(
             "border-top",
@@ -31,7 +27,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjDivider, MjDividerExtra> {
     }
 
     fn get_outlook_width(&self) -> Pixel {
-        let container_width = self.extra.container_width.as_ref().unwrap();
+        let container_width = self.container_width.as_ref().unwrap();
         let padding_horizontal = self.get_padding_horizontal();
         let width = self
             .attribute_as_size("width")
@@ -67,9 +63,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjDivider, MjDividerExtra> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjDivider, MjDividerExtra>
-{
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjDivider, ()> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("center"),
@@ -91,7 +85,7 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn context(&self) -> &'header RenderContext<'header> {
@@ -112,13 +106,7 @@ impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjDivi
         &'element self,
         context: &'header RenderContext<'header>,
     ) -> Box<dyn Render<'element, 'header> + 'r> {
-        Box::new(Renderer::new(
-            context,
-            self,
-            MjDividerExtra {
-                container_width: None,
-            },
-        ))
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_divider/render.rs
+++ b/packages/mrml-core/src/mj_divider/render.rs
@@ -68,7 +68,7 @@ impl<'e, 'h> MjDividerRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjDividerRender<'e, 'h> {
-    fn default_attribute(&self, key: &str) -> Option<&str> {
+    fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("center"),
             "border-color" => Some("#000000"),

--- a/packages/mrml-core/src/mj_divider/render.rs
+++ b/packages/mrml-core/src/mj_divider/render.rs
@@ -1,12 +1,9 @@
-use std::cell::{Ref, RefCell};
-use std::rc::Rc;
-
 use super::{MjDivider, NAME};
 use crate::helper::size::{Pixel, Size};
-use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
+use crate::prelude::render::*;
 
 struct MjDividerRender<'e, 'h> {
-    header: Rc<RefCell<Header<'h>>>,
+    header: &'h Header<'h>,
     element: &'e MjDivider,
     container_width: Option<Pixel>,
 }
@@ -97,11 +94,16 @@ impl<'e, 'h> Render<'e, 'h> for MjDividerRender<'e, 'h> {
         self.container_width = width;
     }
 
-    fn header(&self) -> Ref<Header<'h>> {
-        self.header.borrow()
+    fn header(&self) -> &'h Header<'h> {
+        self.header
     }
 
-    fn render(&self, _opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(
+        &self,
+        _opts: &RenderOptions,
+        _header: &mut VariableHeader,
+        buf: &mut RenderBuffer,
+    ) -> Result<(), Error> {
         let p = self.set_style_p(Tag::new("p"));
         p.render_text(buf, "");
 
@@ -111,7 +113,7 @@ impl<'e, 'h> Render<'e, 'h> for MjDividerRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjDivider {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjDividerRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_divider/render.rs
+++ b/packages/mrml-core/src/mj_divider/render.rs
@@ -2,7 +2,6 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::{MjDivider, NAME};
-use crate::helper::condition::{END_CONDITIONAL_TAG, START_CONDITIONAL_TAG};
 use crate::helper::size::{Pixel, Size};
 use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
 
@@ -63,13 +62,13 @@ impl<'e, 'h> MjDividerRender<'e, 'h> {
             .add_style("height", "0")
             .add_style("line-height", "0");
 
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         table.render_open(buf);
         tr.render_open(buf);
         td.render_text(buf, "&nbsp;");
         tr.render_close(buf);
         table.render_close(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
     }
 }
 

--- a/packages/mrml-core/src/mj_divider/render.rs
+++ b/packages/mrml-core/src/mj_divider/render.rs
@@ -2,7 +2,7 @@ use super::{MjDivider, NAME};
 use crate::helper::size::{Pixel, Size};
 use crate::prelude::render::*;
 
-impl<'element, 'header> Renderer<'element, 'header, MjDivider, ()> {
+impl<'root> Renderer<'root, MjDivider, ()> {
     fn set_style_p_without_width<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style(
             "border-top",
@@ -63,7 +63,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjDivider, ()> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjDivider, ()> {
+impl<'root> Render<'root> for Renderer<'root, MjDivider, ()> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("center"),
@@ -76,7 +76,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -88,7 +88,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         self.container_width = width;
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -101,11 +101,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjDivider {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjDivider {
     fn renderer(
-        &'element self,
-        context: &'header RenderContext<'header>,
-    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/mj_divider/render.rs
+++ b/packages/mrml-core/src/mj_divider/render.rs
@@ -4,8 +4,7 @@ use std::rc::Rc;
 use super::{MjDivider, NAME};
 use crate::helper::condition::conditional_tag;
 use crate::helper::size::{Pixel, Size};
-use crate::helper::tag::Tag;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 struct MjDividerRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,

--- a/packages/mrml-core/src/mj_divider/render.rs
+++ b/packages/mrml-core/src/mj_divider/render.rs
@@ -3,7 +3,7 @@ use crate::helper::size::{Pixel, Size};
 use crate::prelude::render::*;
 
 impl<'root> Renderer<'root, MjDivider, ()> {
-    fn set_style_p_without_width<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_p_without_width<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         tag.add_style(
             "border-top",
             format!(
@@ -16,12 +16,16 @@ impl<'root> Renderer<'root, MjDivider, ()> {
         .add_style("font-size", "1px")
         .add_style("margin", "0px auto")
     }
-    fn set_style_p<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_p<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         self.set_style_p_without_width(tag)
             .maybe_add_style("width", self.attribute("width"))
     }
 
-    fn set_style_outlook<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_outlook<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         self.set_style_p_without_width(tag)
             .add_style("width", self.get_outlook_width().to_string())
     }

--- a/packages/mrml-core/src/mj_divider/render.rs
+++ b/packages/mrml-core/src/mj_divider/render.rs
@@ -3,7 +3,7 @@ use crate::helper::size::{Pixel, Size};
 use crate::prelude::render::*;
 
 struct MjDividerRender<'e, 'h> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e MjDivider,
     container_width: Option<Pixel>,
 }
@@ -94,16 +94,11 @@ impl<'e, 'h> Render<'e, 'h> for MjDividerRender<'e, 'h> {
         self.container_width = width;
     }
 
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        self.context
     }
 
-    fn render(
-        &self,
-        _opts: &RenderOptions,
-        _header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render(&self, _header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
         let p = self.set_style_p(Tag::new("p"));
         p.render_text(buf, "");
 
@@ -113,10 +108,10 @@ impl<'e, 'h> Render<'e, 'h> for MjDividerRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjDivider {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjDividerRender::<'e, 'h> {
             element: self,
-            header,
+            context,
             container_width: None,
         })
     }

--- a/packages/mrml-core/src/mj_divider/render.rs
+++ b/packages/mrml-core/src/mj_divider/render.rs
@@ -98,11 +98,11 @@ impl<'e, 'h> Render<'e, 'h> for MjDividerRender<'e, 'h> {
         self.context
     }
 
-    fn render(&self, _header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let p = self.set_style_p(Tag::new("p"));
-        p.render_text(buf, "");
+        p.render_text(&mut cursor.buffer, "");
 
-        self.render_after(buf);
+        self.render_after(&mut cursor.buffer);
         Ok(())
     }
 }

--- a/packages/mrml-core/src/mj_divider/render.rs
+++ b/packages/mrml-core/src/mj_divider/render.rs
@@ -2,13 +2,11 @@ use super::{MjDivider, NAME};
 use crate::helper::size::{Pixel, Size};
 use crate::prelude::render::*;
 
-struct MjDividerRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e MjDivider,
+struct MjDividerExtra {
     container_width: Option<Pixel>,
 }
 
-impl<'e, 'h> MjDividerRender<'e, 'h> {
+impl<'element, 'header> Renderer<'element, 'header, MjDivider, MjDividerExtra> {
     fn set_style_p_without_width<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style(
             "border-top",
@@ -33,7 +31,7 @@ impl<'e, 'h> MjDividerRender<'e, 'h> {
     }
 
     fn get_outlook_width(&self) -> Pixel {
-        let container_width = self.container_width.as_ref().unwrap();
+        let container_width = self.extra.container_width.as_ref().unwrap();
         let padding_horizontal = self.get_padding_horizontal();
         let width = self
             .attribute_as_size("width")
@@ -69,7 +67,9 @@ impl<'e, 'h> MjDividerRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'e, 'h> for MjDividerRender<'e, 'h> {
+impl<'element, 'header> Render<'element, 'header>
+    for Renderer<'element, 'header, MjDivider, MjDividerExtra>
+{
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("center"),
@@ -82,7 +82,7 @@ impl<'e, 'h> Render<'e, 'h> for MjDividerRender<'e, 'h> {
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -91,10 +91,10 @@ impl<'e, 'h> Render<'e, 'h> for MjDividerRender<'e, 'h> {
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.container_width = width;
+        self.extra.container_width = width;
     }
 
-    fn context(&self) -> &'h RenderContext<'h> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
@@ -107,13 +107,18 @@ impl<'e, 'h> Render<'e, 'h> for MjDividerRender<'e, 'h> {
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjDivider {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjDividerRender::<'e, 'h> {
-            element: self,
+impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjDivider {
+    fn renderer(
+        &'element self,
+        context: &'header RenderContext<'header>,
+    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        Box::new(Renderer::new(
             context,
-            container_width: None,
-        })
+            self,
+            MjDividerExtra {
+                container_width: None,
+            },
+        ))
     }
 }
 

--- a/packages/mrml-core/src/mj_divider/render.rs
+++ b/packages/mrml-core/src/mj_divider/render.rs
@@ -12,7 +12,7 @@ struct MjDividerRender<'e, 'h> {
 }
 
 impl<'e, 'h> MjDividerRender<'e, 'h> {
-    fn set_style_p_without_width(&self, tag: Tag) -> Tag {
+    fn set_style_p_without_width<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style(
             "border-top",
             format!(
@@ -25,12 +25,12 @@ impl<'e, 'h> MjDividerRender<'e, 'h> {
         .add_style("font-size", "1px")
         .add_style("margin", "0px auto")
     }
-    fn set_style_p(&self, tag: Tag) -> Tag {
+    fn set_style_p<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         self.set_style_p_without_width(tag)
             .maybe_add_style("width", self.attribute("width"))
     }
 
-    fn set_style_outlook(&self, tag: Tag) -> Tag {
+    fn set_style_outlook<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         self.set_style_p_without_width(tag)
             .add_style("width", self.get_outlook_width().to_string())
     }

--- a/packages/mrml-core/src/mj_divider/render.rs
+++ b/packages/mrml-core/src/mj_divider/render.rs
@@ -5,7 +5,6 @@ use super::{MjDivider, NAME};
 use crate::helper::condition::conditional_tag;
 use crate::helper::size::{Pixel, Size};
 use crate::helper::tag::Tag;
-use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 struct MjDividerRender<'e, 'h> {
@@ -68,7 +67,7 @@ impl<'e, 'h> MjDividerRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjDividerRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjDividerRender<'e, 'h> {
     fn default_attribute(&self, key: &str) -> Option<&str> {
         match key {
             "align" => Some("center"),
@@ -81,8 +80,8 @@ impl<'e, 'h> Render<'h> for MjDividerRender<'e, 'h> {
         }
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -103,7 +102,7 @@ impl<'e, 'h> Render<'h> for MjDividerRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjDivider {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjDividerRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_group/render.rs
+++ b/packages/mrml-core/src/mj_group/render.rs
@@ -2,7 +2,7 @@ use super::{MjGroup, NAME};
 use crate::helper::size::{Pixel, Size};
 use crate::prelude::render::*;
 
-impl<'element, 'header> Renderer<'element, 'header, MjGroup, ()> {
+impl<'root> Renderer<'root, MjGroup, ()> {
     fn current_width(&self) -> Pixel {
         let parent_width = self.container_width.as_ref().unwrap();
         let non_raw_siblings = self.non_raw_siblings();
@@ -108,7 +108,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjGroup, ()> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjGroup, ()> {
+impl<'root> Render<'root> for Renderer<'root, MjGroup, ()> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "direction" => Some("ltr"),
@@ -116,7 +116,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -124,7 +124,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         Some(NAME)
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -188,11 +188,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjGroup {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjGroup {
     fn renderer(
-        &'element self,
-        context: &'header RenderContext<'header>,
-    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/mj_group/render.rs
+++ b/packages/mrml-core/src/mj_group/render.rs
@@ -4,8 +4,7 @@ use std::rc::Rc;
 use super::{MjGroup, NAME};
 use crate::helper::condition::conditional_tag;
 use crate::helper::size::{Pixel, Size};
-use crate::helper::tag::Tag;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 struct MjGroupRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,

--- a/packages/mrml-core/src/mj_group/render.rs
+++ b/packages/mrml-core/src/mj_group/render.rs
@@ -59,7 +59,7 @@ impl<'e, 'h> MjGroupRender<'e, 'h> {
         (classname.replace('.', "-"), parsed_width)
     }
 
-    fn set_style_root_div(&self, tag: Tag) -> Tag {
+    fn set_style_root_div<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("font-size", "0")
             .add_style("line-height", "0")
             .add_style("text-align", "left")
@@ -70,7 +70,7 @@ impl<'e, 'h> MjGroupRender<'e, 'h> {
             .maybe_add_style("vertical-align", self.attribute("vertical-align"))
     }
 
-    fn set_style_td_outlook(&self, tag: Tag) -> Tag {
+    fn set_style_td_outlook<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("vertical-align", self.attribute("vertical-align"))
             .add_style("width", self.current_width().to_string())
     }
@@ -155,7 +155,7 @@ impl<'e, 'h> Render<'e, 'h> for MjGroupRender<'e, 'h> {
         self.raw_siblings = value;
     }
 
-    fn set_style(&self, name: &str, tag: Tag) -> Tag {
+    fn set_style<'a>(&self, name: &str, tag: Tag<'a>) -> Tag<'a> {
         match name {
             "td-outlook" => self.set_style_td_outlook(tag),
             _ => tag,

--- a/packages/mrml-core/src/mj_group/render.rs
+++ b/packages/mrml-core/src/mj_group/render.rs
@@ -119,7 +119,7 @@ impl<'e, 'h> MjGroupRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjGroupRender<'e, 'h> {
-    fn default_attribute(&self, name: &str) -> Option<&str> {
+    fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "direction" => Some("ltr"),
             _ => None,

--- a/packages/mrml-core/src/mj_group/render.rs
+++ b/packages/mrml-core/src/mj_group/render.rs
@@ -2,7 +2,6 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::{MjGroup, NAME};
-use crate::helper::condition::{END_CONDITIONAL_TAG, START_CONDITIONAL_TAG};
 use crate::helper::size::{Pixel, Size};
 use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
 
@@ -107,13 +106,13 @@ impl<'e, 'h> MjGroupRender<'e, 'h> {
                             .or_else(|| renderer.attribute("width")),
                     );
 
-                buf.push_str(START_CONDITIONAL_TAG);
+                buf.start_conditional_tag();
                 td.render_open(buf);
-                buf.push_str(END_CONDITIONAL_TAG);
+                buf.end_conditional_tag();
                 renderer.render(opts, buf)?;
-                buf.push_str(START_CONDITIONAL_TAG);
+                buf.start_conditional_tag();
                 td.render_close(buf);
-                buf.push_str(END_CONDITIONAL_TAG);
+                buf.end_conditional_tag();
             }
         }
         Ok(())
@@ -186,15 +185,15 @@ impl<'e, 'h> Render<'e, 'h> for MjGroupRender<'e, 'h> {
         let tr = Tag::tr();
 
         div.render_open(buf);
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         table.render_open(buf);
         tr.render_open(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
         self.render_children(opts, buf)?;
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         tr.render_close(buf);
         table.render_close(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
         div.render_close(buf);
 
         Ok(())

--- a/packages/mrml-core/src/mj_group/render.rs
+++ b/packages/mrml-core/src/mj_group/render.rs
@@ -3,14 +3,13 @@ use crate::helper::size::{Pixel, Size};
 use crate::prelude::render::*;
 
 struct MjGroupExtra {
-    container_width: Option<Pixel>,
     siblings: usize,
     raw_siblings: usize,
 }
 
 impl<'element, 'header> Renderer<'element, 'header, MjGroup, MjGroupExtra> {
     fn current_width(&self) -> Pixel {
-        let parent_width = self.extra.container_width.as_ref().unwrap();
+        let parent_width = self.container_width.as_ref().unwrap();
         let non_raw_siblings = self.non_raw_siblings();
         let borders = self.get_border_horizontal();
         let paddings = self.get_padding_horizontal();
@@ -141,7 +140,7 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn set_siblings(&mut self, value: usize) {
@@ -205,7 +204,6 @@ impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjGrou
             context,
             self,
             MjGroupExtra {
-                container_width: None,
                 siblings: 1,
                 raw_siblings: 0,
             },

--- a/packages/mrml-core/src/mj_group/render.rs
+++ b/packages/mrml-core/src/mj_group/render.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use super::{MjGroup, NAME};
 use crate::helper::size::{Pixel, Size};
 use crate::prelude::render::*;
@@ -48,7 +50,11 @@ impl<'root> Renderer<'root, MjGroup, ()> {
         (classname.replace('.', "-"), parsed_width)
     }
 
-    fn set_style_root_div<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_root_div<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.add_style("font-size", "0")
             .add_style("line-height", "0")
             .add_style("text-align", "left")
@@ -59,7 +65,11 @@ impl<'root> Renderer<'root, MjGroup, ()> {
             .maybe_add_style("vertical-align", self.attribute("vertical-align"))
     }
 
-    fn set_style_td_outlook<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_td_outlook<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.maybe_add_style("vertical-align", self.attribute("vertical-align"))
             .add_style("width", self.current_width().to_string())
     }
@@ -91,8 +101,8 @@ impl<'root> Renderer<'root, MjGroup, ()> {
                         "width",
                         renderer
                             .get_width()
-                            .map(|w| w.to_string())
-                            .or_else(|| renderer.attribute("width")),
+                            .map(|w| Cow::Owned(w.to_string()))
+                            .or_else(|| renderer.attribute("width").map(Cow::Borrowed)),
                     );
 
                 cursor.buffer.start_conditional_tag();
@@ -144,7 +154,11 @@ impl<'root> Render<'root> for Renderer<'root, MjGroup, ()> {
         self.raw_siblings = value;
     }
 
-    fn set_style<'a>(&self, name: &str, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style<'a, 't>(&'a self, name: &str, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         match name {
             "td-outlook" => self.set_style_td_outlook(tag),
             _ => tag,

--- a/packages/mrml-core/src/mj_group/render.rs
+++ b/packages/mrml-core/src/mj_group/render.rs
@@ -2,12 +2,7 @@ use super::{MjGroup, NAME};
 use crate::helper::size::{Pixel, Size};
 use crate::prelude::render::*;
 
-struct MjGroupExtra {
-    siblings: usize,
-    raw_siblings: usize,
-}
-
-impl<'element, 'header> Renderer<'element, 'header, MjGroup, MjGroupExtra> {
+impl<'element, 'header> Renderer<'element, 'header, MjGroup, ()> {
     fn current_width(&self) -> Pixel {
         let parent_width = self.container_width.as_ref().unwrap();
         let non_raw_siblings = self.non_raw_siblings();
@@ -35,7 +30,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjGroup, MjGroupExtra> {
     }
 
     fn non_raw_siblings(&self) -> usize {
-        self.extra.siblings - self.extra.raw_siblings
+        self.siblings - self.raw_siblings
     }
 
     fn get_parsed_width(&self) -> Size {
@@ -113,9 +108,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjGroup, MjGroupExtra> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjGroup, MjGroupExtra>
-{
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjGroup, ()> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "direction" => Some("ltr"),
@@ -144,11 +137,11 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_siblings(&mut self, value: usize) {
-        self.extra.siblings = value;
+        self.siblings = value;
     }
 
     fn set_raw_siblings(&mut self, value: usize) {
-        self.extra.raw_siblings = value;
+        self.raw_siblings = value;
     }
 
     fn set_style<'a>(&self, name: &str, tag: Tag<'a>) -> Tag<'a> {
@@ -200,14 +193,7 @@ impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjGrou
         &'element self,
         context: &'header RenderContext<'header>,
     ) -> Box<dyn Render<'element, 'header> + 'r> {
-        Box::new(Renderer::new(
-            context,
-            self,
-            MjGroupExtra {
-                siblings: 1,
-                raw_siblings: 0,
-            },
-        ))
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_group/render.rs
+++ b/packages/mrml-core/src/mj_group/render.rs
@@ -5,7 +5,6 @@ use super::{MjGroup, NAME};
 use crate::helper::condition::conditional_tag;
 use crate::helper::size::{Pixel, Size};
 use crate::helper::tag::Tag;
-use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 struct MjGroupRender<'e, 'h> {
@@ -119,7 +118,7 @@ impl<'e, 'h> MjGroupRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjGroupRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjGroupRender<'e, 'h> {
     fn default_attribute(&self, name: &str) -> Option<&str> {
         match name {
             "direction" => Some("ltr"),
@@ -127,8 +126,8 @@ impl<'e, 'h> Render<'h> for MjGroupRender<'e, 'h> {
         }
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -191,7 +190,7 @@ impl<'e, 'h> Render<'h> for MjGroupRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjGroup {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjGroupRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_group/render.rs
+++ b/packages/mrml-core/src/mj_group/render.rs
@@ -72,11 +72,7 @@ impl<'e, 'h> MjGroupRender<'e, 'h> {
             .add_style("width", self.current_width().to_string())
     }
 
-    fn render_children(
-        &self,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_children(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let current_width = self.current_width();
         let siblings = self.element.children.len();
         let raw_siblings = self
@@ -94,7 +90,7 @@ impl<'e, 'h> MjGroupRender<'e, 'h> {
             renderer.set_container_width(Some(current_width.clone()));
             renderer.add_extra_attribute("mobile-width", "mobile-width");
             if child.is_raw() {
-                renderer.render(header, buf)?;
+                renderer.render(cursor)?;
             } else {
                 let td = Tag::td()
                     .maybe_add_style("align", renderer.attribute("align"))
@@ -107,13 +103,13 @@ impl<'e, 'h> MjGroupRender<'e, 'h> {
                             .or_else(|| renderer.attribute("width")),
                     );
 
-                buf.start_conditional_tag();
-                td.render_open(buf);
-                buf.end_conditional_tag();
-                renderer.render(header, buf)?;
-                buf.start_conditional_tag();
-                td.render_close(buf);
-                buf.end_conditional_tag();
+                cursor.buffer.start_conditional_tag();
+                td.render_open(&mut cursor.buffer);
+                cursor.buffer.end_conditional_tag();
+                renderer.render(cursor)?;
+                cursor.buffer.start_conditional_tag();
+                td.render_close(&mut cursor.buffer);
+                cursor.buffer.end_conditional_tag();
             }
         }
         Ok(())
@@ -163,9 +159,9 @@ impl<'e, 'h> Render<'e, 'h> for MjGroupRender<'e, 'h> {
         }
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let (classname, size) = self.get_column_class();
-        header.add_media_query(classname.clone(), size);
+        cursor.header.add_media_query(classname.clone(), size);
 
         let div = self
             .set_style_root_div(Tag::div())
@@ -184,17 +180,17 @@ impl<'e, 'h> Render<'e, 'h> for MjGroupRender<'e, 'h> {
         );
         let tr = Tag::tr();
 
-        div.render_open(buf);
-        buf.start_conditional_tag();
-        table.render_open(buf);
-        tr.render_open(buf);
-        buf.end_conditional_tag();
-        self.render_children(header, buf)?;
-        buf.start_conditional_tag();
-        tr.render_close(buf);
-        table.render_close(buf);
-        buf.end_conditional_tag();
-        div.render_close(buf);
+        div.render_open(&mut cursor.buffer);
+        cursor.buffer.start_conditional_tag();
+        table.render_open(&mut cursor.buffer);
+        tr.render_open(&mut cursor.buffer);
+        cursor.buffer.end_conditional_tag();
+        self.render_children(cursor)?;
+        cursor.buffer.start_conditional_tag();
+        tr.render_close(&mut cursor.buffer);
+        table.render_close(&mut cursor.buffer);
+        cursor.buffer.end_conditional_tag();
+        div.render_close(&mut cursor.buffer);
 
         Ok(())
     }

--- a/packages/mrml-core/src/mj_head/render.rs
+++ b/packages/mrml-core/src/mj_head/render.rs
@@ -116,12 +116,7 @@ fn render_font_link(target: &mut String, href: &str) {
     target.push_str("\" rel=\"stylesheet\" type=\"text/css\">");
 }
 
-pub struct MjHeadRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e MjHead,
-}
-
-impl<'e, 'h> MjHeadRender<'e, 'h> {
+impl<'element, 'header> Renderer<'element, 'header, MjHead, ()> {
     fn mj_style_iter(&self) -> impl Iterator<Item = &str> {
         self.element.children.iter().flat_map(|item| {
             item.as_mj_include()
@@ -270,8 +265,8 @@ impl<'e, 'h> MjHeadRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'e, 'h> for MjHeadRender<'e, 'h> {
-    fn context(&self) -> &'h RenderContext<'h> {
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjHead, ()> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
@@ -306,10 +301,7 @@ impl<'e, 'h> Render<'e, 'h> for MjHeadRender<'e, 'h> {
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjHead {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjHeadRender::<'e, 'h> {
-            element: self,
-            context,
-        })
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_head/render.rs
+++ b/packages/mrml-core/src/mj_head/render.rs
@@ -2,7 +2,6 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::MjHead;
-use crate::helper::condition::{END_NEGATION_CONDITIONAL_TAG, START_MSO_NEGATION_CONDITIONAL_TAG};
 use crate::helper::sort::sort_by_key;
 use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable};
@@ -181,14 +180,14 @@ impl<'e, 'h> MjHeadRender<'e, 'h> {
         if links.is_empty() && imports.is_empty() {
             return;
         } else {
-            buf.push_str(START_MSO_NEGATION_CONDITIONAL_TAG);
+            buf.start_mso_negation_conditional_tag();
             buf.push_str(&links);
             if !imports.is_empty() {
                 buf.push_str("<style type=\"text/css\">");
                 buf.push_str(&imports);
                 buf.push_str("</style>");
             }
-            buf.push_str(END_NEGATION_CONDITIONAL_TAG);
+            buf.end_negation_conditional_tag();
         }
     }
 
@@ -289,9 +288,9 @@ impl<'e, 'h> Render<'e, 'h> for MjHeadRender<'e, 'h> {
             buf.push_str(title);
         }
         buf.push_str("</title>");
-        buf.push_str(START_MSO_NEGATION_CONDITIONAL_TAG);
+        buf.start_mso_negation_conditional_tag();
         buf.push_str("<meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">");
-        buf.push_str(END_NEGATION_CONDITIONAL_TAG);
+        buf.end_negation_conditional_tag();
         buf.push_str("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">");
         buf.push_str("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">");
         buf.push_str(STYLE_BASE);

--- a/packages/mrml-core/src/mj_head/render.rs
+++ b/packages/mrml-core/src/mj_head/render.rs
@@ -1,10 +1,7 @@
-use std::cell::{Ref, RefCell};
-use std::rc::Rc;
-
 use super::MjHead;
 use crate::helper::sort::sort_by_key;
 use crate::prelude::hash::Map;
-use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable};
+use crate::prelude::render::*;
 
 const STYLE_BASE: &str = r#"
 <style type="text/css">
@@ -120,7 +117,7 @@ fn render_font_link(target: &mut String, href: &str) {
 }
 
 pub struct MjHeadRender<'e, 'h> {
-    header: Rc<RefCell<Header<'h>>>,
+    header: &'h Header<'h>,
     element: &'e MjHead,
 }
 
@@ -156,8 +153,12 @@ impl<'e, 'h> MjHeadRender<'e, 'h> {
         })
     }
 
-    fn render_font_families(&self, opts: &RenderOptions, buf: &mut RenderBuffer) {
-        let header = self.header.borrow();
+    fn render_font_families(
+        &self,
+        opts: &RenderOptions,
+        header: &mut VariableHeader,
+        buf: &mut RenderBuffer,
+    ) {
         let used_font_families = header.used_font_families();
         if used_font_families.is_empty() {
             return;
@@ -166,7 +167,7 @@ impl<'e, 'h> MjHeadRender<'e, 'h> {
         let mut links = String::default();
         let mut imports = String::default();
         for name in header.used_font_families().iter() {
-            if let Some(href) = header.font_families().get(name.as_str()) {
+            if let Some(href) = self.header.font_families().get(name.as_str()) {
                 render_font_link(&mut links, href);
                 render_font_import(&mut imports, href);
             } else if let Some(href) = opts.fonts.get(name) {
@@ -178,7 +179,6 @@ impl<'e, 'h> MjHeadRender<'e, 'h> {
         }
 
         if links.is_empty() && imports.is_empty() {
-            return;
         } else {
             buf.start_mso_negation_conditional_tag();
             buf.push_str(&links);
@@ -191,14 +191,13 @@ impl<'e, 'h> MjHeadRender<'e, 'h> {
         }
     }
 
-    fn render_media_queries(&self, buf: &mut RenderBuffer) {
-        let header = self.header.borrow();
+    fn render_media_queries(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) {
         if header.media_queries().is_empty() {
             return;
         }
         let mut classnames = header.media_queries().iter().collect::<Vec<_>>();
         classnames.sort_by(sort_by_key);
-        let breakpoint = header.breakpoint().to_string();
+        let breakpoint = self.header.breakpoint().to_string();
         buf.push_str("<style type=\"text/css\">");
         buf.push_str("@media only screen and (min-width:");
         buf.push_str(breakpoint.as_str());
@@ -231,8 +230,7 @@ impl<'e, 'h> MjHeadRender<'e, 'h> {
         buf.push_str("</style>");
     }
 
-    fn render_styles(&self, buf: &mut RenderBuffer) {
-        let header = self.header.borrow();
+    fn render_styles(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) {
         if !header.styles().is_empty() {
             buf.push_str("<style type=\"text/css\">");
             header.styles().iter().for_each(|style| {
@@ -249,23 +247,28 @@ impl<'e, 'h> MjHeadRender<'e, 'h> {
         buf.push_str("</style>");
     }
 
-    fn render_raw(&self, opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render_raw(
+        &self,
+        opts: &RenderOptions,
+        header: &mut VariableHeader,
+        buf: &mut RenderBuffer,
+    ) -> Result<(), Error> {
         let mut index: usize = 0;
         let siblings = self.element.children.len();
         for child in self.element.children.iter() {
             if let Some(mj_raw) = child.as_mj_raw() {
-                let mut renderer = mj_raw.renderer(Rc::clone(&self.header));
+                let mut renderer = mj_raw.renderer(self.header);
                 renderer.set_index(index);
                 renderer.set_siblings(siblings);
-                renderer.render(opts, buf)?;
+                renderer.render(opts, header, buf)?;
                 index += 1;
             } else if let Some(mj_include) = child.as_mj_include() {
                 for include_child in mj_include.children.iter() {
                     if let Some(mj_raw) = include_child.as_mj_raw() {
-                        let mut renderer = mj_raw.renderer(Rc::clone(&self.header));
+                        let mut renderer = mj_raw.renderer(self.header);
                         renderer.set_index(index);
                         renderer.set_siblings(siblings);
-                        renderer.render(opts, buf)?;
+                        renderer.render(opts, header, buf)?;
                         index += 1;
                     }
                 }
@@ -276,11 +279,16 @@ impl<'e, 'h> MjHeadRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjHeadRender<'e, 'h> {
-    fn header(&self) -> Ref<Header<'h>> {
-        self.header.borrow()
+    fn header(&self) -> &'h Header<'h> {
+        self.header
     }
 
-    fn render(&self, opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(
+        &self,
+        opts: &RenderOptions,
+        header: &mut VariableHeader,
+        buf: &mut RenderBuffer,
+    ) -> Result<(), Error> {
         buf.push_str("<head>");
         // we write the title even though there is no content
         buf.push_str("<title>");
@@ -294,17 +302,17 @@ impl<'e, 'h> Render<'e, 'h> for MjHeadRender<'e, 'h> {
         buf.push_str("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">");
         buf.push_str("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">");
         buf.push_str(STYLE_BASE);
-        self.render_font_families(opts, buf);
-        self.render_media_queries(buf);
-        self.render_styles(buf);
-        self.render_raw(opts, buf)?;
+        self.render_font_families(opts, header, buf);
+        self.render_media_queries(header, buf);
+        self.render_styles(header, buf);
+        self.render_raw(opts, header, buf)?;
         buf.push_str("</head>");
         Ok(())
     }
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjHead {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjHeadRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_head/render.rs
+++ b/packages/mrml-core/src/mj_head/render.rs
@@ -116,7 +116,7 @@ fn render_font_link(target: &mut String, href: &str) {
     target.push_str("\" rel=\"stylesheet\" type=\"text/css\">");
 }
 
-impl<'element, 'header> Renderer<'element, 'header, MjHead, ()> {
+impl<'root> Renderer<'root, MjHead, ()> {
     fn mj_style_iter(&self) -> impl Iterator<Item = &str> {
         self.element.children.iter().flat_map(|item| {
             item.as_mj_include()
@@ -265,8 +265,8 @@ impl<'element, 'header> Renderer<'element, 'header, MjHead, ()> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjHead, ()> {
-    fn context(&self) -> &'header RenderContext<'header> {
+impl<'root> Render<'root> for Renderer<'root, MjHead, ()> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -299,8 +299,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjHead {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjHead {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/mj_head/render.rs
+++ b/packages/mrml-core/src/mj_head/render.rs
@@ -283,7 +283,7 @@ impl<'e, 'h> MjHeadRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjHeadRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjHeadRender<'e, 'h> {
     fn header(&self) -> Ref<Header<'h>> {
         self.header.borrow()
     }
@@ -315,7 +315,7 @@ impl<'e, 'h> Render<'h> for MjHeadRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjHead {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjHeadRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_hero/render.rs
+++ b/packages/mrml-core/src/mj_hero/render.rs
@@ -2,7 +2,7 @@ use super::{MjHero, NAME};
 use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
-impl<'element, 'header> Renderer<'element, 'header, MjHero, ()> {
+impl<'root> Renderer<'root, MjHero, ()> {
     fn set_style_div<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("margin", "0 auto").maybe_add_style(
             "max-width",
@@ -241,7 +241,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjHero, ()> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjHero, ()> {
+impl<'root> Render<'root> for Renderer<'root, MjHero, ()> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "background-color" => Some("#ffffff"),
@@ -254,7 +254,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -262,7 +262,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         Some(NAME)
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -329,8 +329,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjHero {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjHero {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/mj_hero/render.rs
+++ b/packages/mrml-core/src/mj_hero/render.rs
@@ -2,21 +2,7 @@ use super::{MjHero, NAME};
 use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
-struct MjHeroExtra {
-    siblings: usize,
-    raw_siblings: usize,
-}
-
-impl MjHeroExtra {
-    fn new(siblings: usize, raw_siblings: usize) -> Self {
-        Self {
-            siblings,
-            raw_siblings,
-        }
-    }
-}
-
-impl<'element, 'header> Renderer<'element, 'header, MjHero, MjHeroExtra> {
+impl<'element, 'header> Renderer<'element, 'header, MjHero, ()> {
     fn set_style_div<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("margin", "0 auto").maybe_add_style(
             "max-width",
@@ -255,9 +241,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjHero, MjHeroExtra> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjHero, MjHeroExtra>
-{
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjHero, ()> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "background-color" => Some("#ffffff"),
@@ -287,11 +271,11 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_siblings(&mut self, value: usize) {
-        self.extra.siblings = value;
+        self.siblings = value;
     }
 
     fn set_raw_siblings(&mut self, value: usize) {
-        self.extra.raw_siblings = value;
+        self.raw_siblings = value;
     }
 
     fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
@@ -347,7 +331,7 @@ impl<'element, 'header> Render<'element, 'header>
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjHero {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(Renderer::new(context, self, MjHeroExtra::new(1, 0)))
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_hero/render.rs
+++ b/packages/mrml-core/src/mj_hero/render.rs
@@ -14,22 +14,22 @@ struct MjHeroRender<'e, 'h> {
 }
 
 impl<'e, 'h> MjHeroRender<'e, 'h> {
-    fn set_style_div(&self, tag: Tag) -> Tag {
+    fn set_style_div<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("margin", "0 auto").maybe_add_style(
             "max-width",
             self.container_width.as_ref().map(|w| w.to_string()),
         )
     }
 
-    fn set_style_table(&self, tag: Tag) -> Tag {
+    fn set_style_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("width", "100%")
     }
 
-    fn set_style_tr(&self, tag: Tag) -> Tag {
+    fn set_style_tr<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("vertical-align", "top")
     }
 
-    fn set_style_td_fluid(&self, tag: Tag) -> Tag {
+    fn set_style_td_fluid<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         // TODO check size type compatibility
         let bg_ratio = self
             .attribute_as_size("background-height")
@@ -42,18 +42,18 @@ impl<'e, 'h> MjHeroRender<'e, 'h> {
             .add_style("width", "0.01%")
     }
 
-    fn set_style_outlook_table(&self, tag: Tag) -> Tag {
+    fn set_style_outlook_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style(
             "width",
             self.container_width.as_ref().map(|w| w.to_string()),
         )
     }
 
-    fn set_style_outlook_inner_table(&self, tag: Tag) -> Tag {
+    fn set_style_outlook_inner_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         self.set_style_outlook_table(tag)
     }
 
-    fn set_style_outlook_inner_td(&self, tag: Tag) -> Tag {
+    fn set_style_outlook_inner_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("background-color", self.attribute("inner-background-color"))
             .maybe_add_style("padding", self.attribute("inner-padding"))
             .maybe_add_style("padding-top", self.attribute("inner-padding-top"))
@@ -62,18 +62,18 @@ impl<'e, 'h> MjHeroRender<'e, 'h> {
             .maybe_add_style("padding-left", self.attribute("inner-padding-left"))
     }
 
-    fn set_style_inner_div(&self, tag: Tag) -> Tag {
+    fn set_style_inner_div<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("background-color", self.attribute("inner-background-color"))
             .maybe_add_style("float", self.attribute("align"))
             .add_style("margin", "0px auto")
             .maybe_add_style("width", self.attribute("width"))
     }
 
-    fn set_style_inner_table(&self, tag: Tag) -> Tag {
+    fn set_style_inner_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("width", "100%").add_style("margin", "0px")
     }
 
-    fn set_style_outlook_image(&self, tag: Tag) -> Tag {
+    fn set_style_outlook_image<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("border", "0")
             .maybe_add_style("height", self.attribute("background-height"))
             .add_style("mso-position-horizontal", "center")
@@ -87,7 +87,7 @@ impl<'e, 'h> MjHeroRender<'e, 'h> {
             .add_style("z-index", "-3")
     }
 
-    fn set_style_outlook_td(&self, tag: Tag) -> Tag {
+    fn set_style_outlook_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("line-height", "0")
             .add_style("font-size", "0")
             .add_style("mso-line-height-rule", "exactly")
@@ -108,7 +108,7 @@ impl<'e, 'h> MjHeroRender<'e, 'h> {
             .or_else(|| self.attribute("background-color"))
     }
 
-    fn set_style_hero(&self, tag: Tag) -> Tag {
+    fn set_style_hero<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("background", self.get_background())
             .maybe_add_style("background-position", self.attribute("background-position"))
             .add_style("background-repeat", "no-repeat")

--- a/packages/mrml-core/src/mj_hero/render.rs
+++ b/packages/mrml-core/src/mj_hero/render.rs
@@ -216,7 +216,7 @@ impl<'e, 'h> MjHeroRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjHeroRender<'e, 'h> {
-    fn default_attribute(&self, name: &str) -> Option<&str> {
+    fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "background-color" => Some("#ffffff"),
             "background-position" => Some("center center"),

--- a/packages/mrml-core/src/mj_hero/render.rs
+++ b/packages/mrml-core/src/mj_hero/render.rs
@@ -4,8 +4,7 @@ use std::rc::Rc;
 use super::{MjHero, NAME};
 use crate::helper::condition::conditional_tag;
 use crate::helper::size::Pixel;
-use crate::helper::tag::Tag;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 struct MjHeroRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,

--- a/packages/mrml-core/src/mj_hero/render.rs
+++ b/packages/mrml-core/src/mj_hero/render.rs
@@ -5,7 +5,6 @@ use super::{MjHero, NAME};
 use crate::helper::condition::conditional_tag;
 use crate::helper::size::Pixel;
 use crate::helper::tag::Tag;
-use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 struct MjHeroRender<'e, 'h> {
@@ -216,7 +215,7 @@ impl<'e, 'h> MjHeroRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjHeroRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjHeroRender<'e, 'h> {
     fn default_attribute(&self, name: &str) -> Option<&str> {
         match name {
             "background-color" => Some("#ffffff"),
@@ -229,8 +228,8 @@ impl<'e, 'h> Render<'h> for MjHeroRender<'e, 'h> {
         }
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -285,7 +284,7 @@ impl<'e, 'h> Render<'h> for MjHeroRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjHero {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjHeroRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_hero/render.rs
+++ b/packages/mrml-core/src/mj_hero/render.rs
@@ -3,7 +3,6 @@ use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
 struct MjHeroExtra {
-    container_width: Option<Pixel>,
     siblings: usize,
     raw_siblings: usize,
 }
@@ -11,7 +10,6 @@ struct MjHeroExtra {
 impl MjHeroExtra {
     fn new(siblings: usize, raw_siblings: usize) -> Self {
         Self {
-            container_width: None,
             siblings,
             raw_siblings,
         }
@@ -22,7 +20,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjHero, MjHeroExtra> {
     fn set_style_div<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("margin", "0 auto").maybe_add_style(
             "max-width",
-            self.extra.container_width.as_ref().map(|w| w.to_string()),
+            self.container_width.as_ref().map(|w| w.to_string()),
         )
     }
 
@@ -50,7 +48,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjHero, MjHeroExtra> {
     fn set_style_outlook_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style(
             "width",
-            self.extra.container_width.as_ref().map(|w| w.to_string()),
+            self.container_width.as_ref().map(|w| w.to_string()),
         )
     }
 
@@ -87,7 +85,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjHero, MjHeroExtra> {
             .maybe_add_style(
                 "width",
                 self.attribute("background-width")
-                    .or_else(|| self.extra.container_width.as_ref().map(|w| w.to_string())),
+                    .or_else(|| self.container_width.as_ref().map(|w| w.to_string())),
             )
             .add_style("z-index", "-3")
     }
@@ -173,10 +171,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjHero, MjHeroExtra> {
             .maybe_add_attribute("align", self.attribute("align"))
             .maybe_add_attribute(
                 "width",
-                self.extra
-                    .container_width
-                    .as_ref()
-                    .map(|w| w.value().to_string()),
+                self.container_width.as_ref().map(|w| w.value().to_string()),
             );
         let tbody = Tag::tbody();
         let tr = Tag::tr();
@@ -288,7 +283,7 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn set_siblings(&mut self, value: usize) {
@@ -305,10 +300,7 @@ impl<'element, 'header> Render<'element, 'header>
             .add_attribute("align", "center")
             .maybe_add_attribute(
                 "width",
-                self.extra
-                    .container_width
-                    .as_ref()
-                    .map(|v| v.value().to_string()),
+                self.container_width.as_ref().map(|v| v.value().to_string()),
             );
         let outlook_tr = Tag::tr();
         let outlook_td = self.set_style_outlook_td(Tag::td());

--- a/packages/mrml-core/src/mj_hero/render.rs
+++ b/packages/mrml-core/src/mj_hero/render.rs
@@ -2,7 +2,6 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::{MjHero, NAME};
-use crate::helper::condition::{END_CONDITIONAL_TAG, START_CONDITIONAL_TAG};
 use crate::helper::size::Pixel;
 use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
 
@@ -181,11 +180,11 @@ impl<'e, 'h> MjHeroRender<'e, 'h> {
             .add_class("mj-hero-content");
         let inner_table = self.set_style_inner_table(Tag::table_presentation());
 
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         table.render_open(buf);
         tr.render_open(buf);
         outlook_inner_td.render_open(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
 
         outlook_inner_div.render_open(buf);
         inner_table.render_open(buf);
@@ -203,11 +202,11 @@ impl<'e, 'h> MjHeroRender<'e, 'h> {
         inner_table.render_close(buf);
         outlook_inner_div.render_close(buf);
 
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         outlook_inner_td.render_close(buf);
         tr.render_close(buf);
         table.render_close(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
 
         Ok(())
     }
@@ -312,12 +311,12 @@ impl<'e, 'h> Render<'e, 'h> for MjHeroRender<'e, 'h> {
         let tbody = Tag::tbody();
         let tr = self.set_style_tr(Tag::tr());
 
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         outlook_table.render_open(buf);
         outlook_tr.render_open(buf);
         outlook_td.render_open(buf);
         v_image.render_closed(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
 
         div.render_open(buf);
         table.render_open(buf);
@@ -331,11 +330,11 @@ impl<'e, 'h> Render<'e, 'h> for MjHeroRender<'e, 'h> {
         table.render_close(buf);
         div.render_close(buf);
 
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         outlook_td.render_close(buf);
         outlook_tr.render_close(buf);
         outlook_table.render_close(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
 
         Ok(())
     }

--- a/packages/mrml-core/src/mj_image/render.rs
+++ b/packages/mrml-core/src/mj_image/render.rs
@@ -1,12 +1,9 @@
-use std::cell::{Ref, RefCell};
-use std::rc::Rc;
-
 use super::{MjImage, NAME};
 use crate::helper::size::Pixel;
-use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
+use crate::prelude::render::*;
 
 struct MjImageRender<'e, 'h> {
-    header: Rc<RefCell<Header<'h>>>,
+    header: &'h Header<'h>,
     element: &'e MjImage,
     container_width: Option<Pixel>,
 }
@@ -127,7 +124,7 @@ impl<'e, 'h> MjImageRender<'e, 'h> {
                 td.mj-full-width-mobile {{ width: auto !important; }}
             }}
             "#,
-            self.header.borrow().breakpoint().lower().to_string(),
+            self.header.breakpoint().lower().to_string(),
         )
     }
 }
@@ -157,13 +154,17 @@ impl<'e, 'h> Render<'e, 'h> for MjImageRender<'e, 'h> {
         self.container_width = width;
     }
 
-    fn header(&self) -> Ref<Header<'h>> {
-        self.header.borrow()
+    fn header(&self) -> &'h Header<'h> {
+        self.header
     }
 
-    fn render(&self, _opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
-        let style = self.render_style();
-        self.header.borrow_mut().add_style(style);
+    fn render(
+        &self,
+        _opts: &RenderOptions,
+        header: &mut VariableHeader,
+        buf: &mut RenderBuffer,
+    ) -> Result<(), Error> {
+        header.add_style(self.render_style());
         //
         let class = if self.is_fluid_on_mobile() {
             Some("mj-full-width-mobile")
@@ -198,7 +199,7 @@ impl<'e, 'h> Render<'e, 'h> for MjImageRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjImage {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjImageRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_image/render.rs
+++ b/packages/mrml-core/src/mj_image/render.rs
@@ -158,8 +158,8 @@ impl<'e, 'h> Render<'e, 'h> for MjImageRender<'e, 'h> {
         self.context
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
-        header.add_style(self.render_style());
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
+        cursor.header.add_style(self.render_style());
         //
         let class = if self.is_fluid_on_mobile() {
             Some("mj-full-width-mobile")
@@ -173,21 +173,21 @@ impl<'e, 'h> Render<'e, 'h> for MjImageRender<'e, 'h> {
         let tr = Tag::tr();
         let td = self.set_style_td(Tag::td()).maybe_add_class(class);
 
-        table.render_open(buf);
-        tbody.render_open(buf);
-        tr.render_open(buf);
-        td.render_open(buf);
+        table.render_open(&mut cursor.buffer);
+        tbody.render_open(&mut cursor.buffer);
+        tr.render_open(&mut cursor.buffer);
+        td.render_open(&mut cursor.buffer);
 
         if self.attribute_exists("href") {
-            self.render_link(buf);
+            self.render_link(&mut cursor.buffer);
         } else {
-            self.render_image(buf);
+            self.render_image(&mut cursor.buffer);
         }
 
-        td.render_close(buf);
-        tr.render_close(buf);
-        tbody.render_close(buf);
-        table.render_close(buf);
+        td.render_close(&mut cursor.buffer);
+        tr.render_close(&mut cursor.buffer);
+        tbody.render_close(&mut cursor.buffer);
+        table.render_close(&mut cursor.buffer);
 
         Ok(())
     }

--- a/packages/mrml-core/src/mj_image/render.rs
+++ b/packages/mrml-core/src/mj_image/render.rs
@@ -3,7 +3,7 @@ use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
 struct MjImageRender<'e, 'h> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e MjImage,
     container_width: Option<Pixel>,
 }
@@ -124,7 +124,7 @@ impl<'e, 'h> MjImageRender<'e, 'h> {
                 td.mj-full-width-mobile {{ width: auto !important; }}
             }}
             "#,
-            self.header.breakpoint().lower().to_string(),
+            self.context.header.breakpoint().lower().to_string(),
         )
     }
 }
@@ -154,16 +154,11 @@ impl<'e, 'h> Render<'e, 'h> for MjImageRender<'e, 'h> {
         self.container_width = width;
     }
 
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        self.context
     }
 
-    fn render(
-        &self,
-        _opts: &RenderOptions,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
         header.add_style(self.render_style());
         //
         let class = if self.is_fluid_on_mobile() {
@@ -199,10 +194,10 @@ impl<'e, 'h> Render<'e, 'h> for MjImageRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjImage {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjImageRender::<'e, 'h> {
             element: self,
-            header,
+            context,
             container_width: None,
         })
     }

--- a/packages/mrml-core/src/mj_image/render.rs
+++ b/packages/mrml-core/src/mj_image/render.rs
@@ -3,8 +3,7 @@ use std::rc::Rc;
 
 use super::{MjImage, NAME};
 use crate::helper::size::Pixel;
-use crate::helper::tag::Tag;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 struct MjImageRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,

--- a/packages/mrml-core/src/mj_image/render.rs
+++ b/packages/mrml-core/src/mj_image/render.rs
@@ -2,7 +2,7 @@ use super::{MjImage, NAME};
 use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
-impl<'element, 'header> Renderer<'element, 'header, MjImage, ()> {
+impl<'root> Renderer<'root, MjImage, ()> {
     fn is_fluid_on_mobile(&self) -> bool {
         self.attribute("fluid-on-mobile")
             .and_then(|value| value.parse::<bool>().ok())
@@ -123,7 +123,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjImage, ()> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjImage, ()> {
+impl<'root> Render<'root> for Renderer<'root, MjImage, ()> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("center"),
@@ -136,7 +136,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -148,7 +148,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         self.container_width = width;
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -187,8 +187,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjImage {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjImage {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/mj_image/render.rs
+++ b/packages/mrml-core/src/mj_image/render.rs
@@ -46,7 +46,7 @@ impl<'e, 'h> MjImageRender<'e, 'h> {
             .or_else(|| self.get_box_width())
     }
 
-    fn set_style_img(&self, tag: Tag) -> Tag {
+    fn set_style_img<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         let tag = tag
             .maybe_add_style("border", self.attribute("border"))
             .maybe_add_style("border-left", self.attribute("left"))
@@ -69,7 +69,7 @@ impl<'e, 'h> MjImageRender<'e, 'h> {
         tag.maybe_add_style("font-size", self.attribute("font-size"))
     }
 
-    fn set_style_td(&self, tag: Tag) -> Tag {
+    fn set_style_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         if self.is_full_width() {
             tag
         } else {
@@ -77,7 +77,7 @@ impl<'e, 'h> MjImageRender<'e, 'h> {
         }
     }
 
-    fn set_style_table(&self, tag: Tag) -> Tag {
+    fn set_style_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         let tag = if self.is_full_width() {
             tag.add_style("min-width", "100%")
                 .add_style("max-width", "100%")

--- a/packages/mrml-core/src/mj_image/render.rs
+++ b/packages/mrml-core/src/mj_image/render.rs
@@ -37,7 +37,11 @@ impl<'root> Renderer<'root, MjImage, ()> {
             .or_else(|| self.get_box_width())
     }
 
-    fn set_style_img<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_img<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         let tag = tag
             .maybe_add_style("border", self.attribute("border"))
             .maybe_add_style("border-left", self.attribute("left"))
@@ -60,7 +64,7 @@ impl<'root> Renderer<'root, MjImage, ()> {
         tag.maybe_add_style("font-size", self.attribute("font-size"))
     }
 
-    fn set_style_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_td<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         if self.is_full_width() {
             tag
         } else {
@@ -68,7 +72,7 @@ impl<'root> Renderer<'root, MjImage, ()> {
         }
     }
 
-    fn set_style_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_table<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         let tag = if self.is_full_width() {
             tag.add_style("min-width", "100%")
                 .add_style("max-width", "100%")

--- a/packages/mrml-core/src/mj_image/render.rs
+++ b/packages/mrml-core/src/mj_image/render.rs
@@ -133,7 +133,7 @@ impl<'e, 'h> MjImageRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjImageRender<'e, 'h> {
-    fn default_attribute(&self, key: &str) -> Option<&str> {
+    fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("center"),
             "border" => Some("0"),

--- a/packages/mrml-core/src/mj_image/render.rs
+++ b/packages/mrml-core/src/mj_image/render.rs
@@ -4,7 +4,6 @@ use std::rc::Rc;
 use super::{MjImage, NAME};
 use crate::helper::size::Pixel;
 use crate::helper::tag::Tag;
-use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 struct MjImageRender<'e, 'h> {
@@ -133,7 +132,7 @@ impl<'e, 'h> MjImageRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjImageRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjImageRender<'e, 'h> {
     fn default_attribute(&self, key: &str) -> Option<&str> {
         match key {
             "align" => Some("center"),
@@ -146,8 +145,8 @@ impl<'e, 'h> Render<'h> for MjImageRender<'e, 'h> {
         }
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -186,7 +185,7 @@ impl<'e, 'h> Render<'h> for MjImageRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjImage {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjImageRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_image/render.rs
+++ b/packages/mrml-core/src/mj_image/render.rs
@@ -2,12 +2,7 @@ use super::{MjImage, NAME};
 use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
-#[derive(Default)]
-struct MjImageExtra {
-    container_width: Option<Pixel>,
-}
-
-impl<'element, 'header> Renderer<'element, 'header, MjImage, MjImageExtra> {
+impl<'element, 'header> Renderer<'element, 'header, MjImage, ()> {
     fn is_fluid_on_mobile(&self) -> bool {
         self.attribute("fluid-on-mobile")
             .and_then(|value| value.parse::<bool>().ok())
@@ -19,7 +14,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjImage, MjImageExtra> {
     }
 
     fn get_box_width(&self) -> Option<Pixel> {
-        self.extra.container_width.as_ref().map(|width| {
+        self.container_width.as_ref().map(|width| {
             let hborder = self.get_border_horizontal();
             let hpadding = self.get_padding_horizontal();
             Pixel::new(width.value() - hborder.value() - hpadding.value())
@@ -128,9 +123,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjImage, MjImageExtra> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjImage, MjImageExtra>
-{
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjImage, ()> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("center"),
@@ -152,7 +145,7 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn context(&self) -> &'header RenderContext<'header> {
@@ -196,7 +189,7 @@ impl<'element, 'header> Render<'element, 'header>
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjImage {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(Renderer::new(context, self, MjImageExtra::default()))
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_include/body/render.rs
+++ b/packages/mrml-core/src/mj_include/body/render.rs
@@ -50,7 +50,7 @@ impl<'e, 'h> Render<'e, 'h> for MjIncludeBodyRender<'e, 'h> {
         None
     }
 
-    fn default_attribute(&self, _: &str) -> Option<&str> {
+    fn default_attribute(&self, _: &str) -> Option<&'static str> {
         None
     }
 

--- a/packages/mrml-core/src/mj_include/body/render.rs
+++ b/packages/mrml-core/src/mj_include/body/render.rs
@@ -2,7 +2,6 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::{MjIncludeBody, MjIncludeBodyChild};
-use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 impl MjIncludeBodyChild {
@@ -31,12 +30,12 @@ impl MjIncludeBodyChild {
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjIncludeBodyChild {
+impl<'r, 'e: 'r, 'h: 'r + 'e> Renderable<'r, 'e, 'h> for MjIncludeBodyChild {
     fn is_raw(&self) -> bool {
         self.as_renderable().is_raw()
     }
 
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         self.as_renderable().renderer(header)
     }
 }
@@ -46,12 +45,12 @@ struct MjIncludeBodyRender<'e, 'h> {
     element: &'e MjIncludeBody,
 }
 
-impl<'e, 'h> Render<'h> for MjIncludeBodyRender<'e, 'h> {
-    fn attributes(&self) -> Option<&Map<String, String>> {
+impl<'e, 'h> Render<'e, 'h> for MjIncludeBodyRender<'e, 'h> {
+    fn raw_attribute(&self, _: &str) -> Option<&'e str> {
         None
     }
 
-    fn default_attribute(&self, _key: &str) -> Option<&str> {
+    fn default_attribute(&self, _: &str) -> Option<&str> {
         None
     }
 
@@ -72,7 +71,7 @@ impl<'e, 'h> Render<'h> for MjIncludeBodyRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjIncludeBody {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjIncludeBodyRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_include/body/render.rs
+++ b/packages/mrml-core/src/mj_include/body/render.rs
@@ -89,31 +89,31 @@ mod tests {
     use crate::mj_raw::{MjRaw, MjRawChild};
     use crate::mj_text::MjText;
     use crate::node::Node;
-    use crate::prelude::render::{Header, RenderOptions, Renderable};
+    use crate::prelude::render::{Header, RenderBuffer, RenderOptions, Renderable};
     use crate::text::Text;
 
     #[test]
     fn basic_mjml_kind() {
         let opts = RenderOptions::default();
         let mj_head = Some(MjHead::default());
-        let expected = {
+        let expected: String = {
             let header = Rc::new(RefCell::new(Header::new(&mj_head)));
             let elt = MjText::default();
             let renderer = elt.renderer(header);
-            let mut buf = String::default();
+            let mut buf = RenderBuffer::default();
             renderer.render(&opts, &mut buf).unwrap();
-            buf
+            buf.into()
         };
-        let result = {
+        let result: String = {
             let header = Rc::new(RefCell::new(Header::new(&mj_head)));
             let mut elt = MjIncludeBody::default();
             elt.attributes.path = "memory:foo.mjml".to_string();
             elt.children
                 .push(MjIncludeBodyChild::MjText(MjText::default()));
             let renderer = elt.renderer(header);
-            let mut buf = String::default();
+            let mut buf = RenderBuffer::default();
             renderer.render(&opts, &mut buf).unwrap();
-            buf
+            buf.into()
         };
         assert_eq!(expected, result);
     }
@@ -123,7 +123,7 @@ mod tests {
         let opts = RenderOptions::default();
         let mj_head = Some(MjHead::default());
 
-        let expected = {
+        let expected: String = {
             let header = Rc::new(RefCell::new(Header::new(&mj_head)));
 
             let mut node = Node::new("span".to_string());
@@ -133,11 +133,11 @@ mod tests {
             let mut root = MjRaw::default();
             root.children.push(MjRawChild::Node(node));
             let renderer = root.renderer(header);
-            let mut buf = String::default();
+            let mut buf = RenderBuffer::default();
             renderer.render(&opts, &mut buf).unwrap();
-            buf
+            buf.into()
         };
-        let result = {
+        let result: String = {
             let header = Rc::new(RefCell::new(Header::new(&mj_head)));
 
             let mut node = Node::new("span".to_string());
@@ -150,9 +150,9 @@ mod tests {
             elt.children.push(MjIncludeBodyChild::Node(node));
 
             let renderer = elt.renderer(header);
-            let mut buf = String::default();
+            let mut buf = RenderBuffer::default();
             renderer.render(&opts, &mut buf).unwrap();
-            buf
+            buf.into()
         };
         assert_eq!(expected, result);
     }

--- a/packages/mrml-core/src/mj_include/body/render.rs
+++ b/packages/mrml-core/src/mj_include/body/render.rs
@@ -2,7 +2,9 @@ use super::{MjIncludeBody, MjIncludeBodyChild};
 use crate::prelude::render::*;
 
 impl MjIncludeBodyChild {
-    pub fn as_renderable<'r, 'e: 'r, 'h: 'r>(&'e self) -> &'e (dyn Renderable<'r, 'e, 'h> + 'e) {
+    pub fn as_renderable<'render, 'root: 'render>(
+        &'root self,
+    ) -> &'root (dyn Renderable<'render, 'root> + 'root) {
         match self {
             Self::Comment(elt) => elt,
             Self::MjAccordion(elt) => elt,
@@ -27,20 +29,21 @@ impl MjIncludeBodyChild {
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r + 'e> Renderable<'r, 'e, 'h> for MjIncludeBodyChild {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjIncludeBodyChild {
     fn is_raw(&self) -> bool {
         self.as_renderable().is_raw()
     }
 
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         self.as_renderable().renderer(context)
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjIncludeBody, ()>
-{
-    fn raw_attribute(&self, _: &str) -> Option<&'element str> {
+impl<'root> Render<'root> for Renderer<'root, MjIncludeBody, ()> {
+    fn raw_attribute(&self, _: &str) -> Option<&'root str> {
         None
     }
 
@@ -48,7 +51,7 @@ impl<'element, 'header> Render<'element, 'header>
         None
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -63,8 +66,11 @@ impl<'element, 'header> Render<'element, 'header>
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjIncludeBody {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjIncludeBody {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/mj_include/body/render.rs
+++ b/packages/mrml-core/src/mj_include/body/render.rs
@@ -37,13 +37,10 @@ impl<'r, 'e: 'r, 'h: 'r + 'e> Renderable<'r, 'e, 'h> for MjIncludeBodyChild {
     }
 }
 
-struct MjIncludeBodyRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e MjIncludeBody,
-}
-
-impl<'e, 'h> Render<'e, 'h> for MjIncludeBodyRender<'e, 'h> {
-    fn raw_attribute(&self, _: &str) -> Option<&'e str> {
+impl<'element, 'header> Render<'element, 'header>
+    for Renderer<'element, 'header, MjIncludeBody, ()>
+{
+    fn raw_attribute(&self, _: &str) -> Option<&'element str> {
         None
     }
 
@@ -51,7 +48,7 @@ impl<'e, 'h> Render<'e, 'h> for MjIncludeBodyRender<'e, 'h> {
         None
     }
 
-    fn context(&self) -> &'h RenderContext<'h> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
@@ -68,10 +65,7 @@ impl<'e, 'h> Render<'e, 'h> for MjIncludeBodyRender<'e, 'h> {
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjIncludeBody {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjIncludeBodyRender::<'e, 'h> {
-            element: self,
-            context,
-        })
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_navbar/render.rs
+++ b/packages/mrml-core/src/mj_navbar/render.rs
@@ -12,7 +12,6 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjNavbarChild {
 }
 
 struct MjNavbarExtra {
-    container_width: Option<Pixel>,
     siblings: usize,
     raw_siblings: usize,
     id: String,
@@ -21,7 +20,6 @@ struct MjNavbarExtra {
 impl MjNavbarExtra {
     fn new(siblings: usize, raw_siblings: usize, id: String) -> Self {
         Self {
-            container_width: None,
             siblings,
             raw_siblings,
             id,
@@ -178,14 +176,13 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn get_width(&self) -> Option<Size> {
-        self.extra
-            .container_width
+        self.container_width
             .as_ref()
             .map(|w| Size::Pixel(w.clone()))
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn set_siblings(&mut self, value: usize) {

--- a/packages/mrml-core/src/mj_navbar/render.rs
+++ b/packages/mrml-core/src/mj_navbar/render.rs
@@ -126,7 +126,7 @@ impl<'e, 'h> MjNavbarRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjNavbarRender<'e, 'h> {
-    fn default_attribute(&self, name: &str) -> Option<&str> {
+    fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "align" => Some("center"),
             "ico-align" => Some("center"),

--- a/packages/mrml-core/src/mj_navbar/render.rs
+++ b/packages/mrml-core/src/mj_navbar/render.rs
@@ -206,7 +206,7 @@ impl<'root> Render<'root> for Renderer<'root, MjNavbar, MjNavbarExtra> {
 
         for child in self.element.children.iter() {
             let mut renderer = child.renderer(self.context());
-            renderer.maybe_add_extra_attribute("navbar-base-url", base_url.map(|v| v.to_owned()));
+            renderer.maybe_add_extra_attribute("navbar-base-url", base_url);
             renderer.render(cursor)?;
         }
 

--- a/packages/mrml-core/src/mj_navbar/render.rs
+++ b/packages/mrml-core/src/mj_navbar/render.rs
@@ -184,8 +184,8 @@ impl<'e, 'h> Render<'e, 'h> for MjNavbarRender<'e, 'h> {
         self.raw_siblings = value;
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
-        header.add_style(self.render_style());
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
+        cursor.header.add_style(self.render_style());
 
         let div = Tag::div().add_class("mj-inline-links");
         let table = Tag::table_presentation().maybe_add_attribute("align", self.attribute("align"));
@@ -193,26 +193,26 @@ impl<'e, 'h> Render<'e, 'h> for MjNavbarRender<'e, 'h> {
         let base_url = self.attribute("base-url");
 
         if self.has_hamburger() {
-            self.render_hamburger(buf);
+            self.render_hamburger(&mut cursor.buffer);
         }
 
-        div.render_open(buf);
-        buf.start_conditional_tag();
-        table.render_open(buf);
-        tr.render_open(buf);
-        buf.end_conditional_tag();
+        div.render_open(&mut cursor.buffer);
+        cursor.buffer.start_conditional_tag();
+        table.render_open(&mut cursor.buffer);
+        tr.render_open(&mut cursor.buffer);
+        cursor.buffer.end_conditional_tag();
 
         for child in self.element.children.iter() {
             let mut renderer = child.renderer(self.context());
             renderer.maybe_add_extra_attribute("navbar-base-url", base_url.clone());
-            renderer.render(header, buf)?;
+            renderer.render(cursor)?;
         }
 
-        buf.start_conditional_tag();
-        tr.render_close(buf);
-        table.render_close(buf);
-        buf.end_conditional_tag();
-        div.render_close(buf);
+        cursor.buffer.start_conditional_tag();
+        tr.render_close(&mut cursor.buffer);
+        table.render_close(&mut cursor.buffer);
+        cursor.buffer.end_conditional_tag();
+        div.render_close(&mut cursor.buffer);
 
         Ok(())
     }

--- a/packages/mrml-core/src/mj_navbar/render.rs
+++ b/packages/mrml-core/src/mj_navbar/render.rs
@@ -12,19 +12,7 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjNavbarChild {
 }
 
 struct MjNavbarExtra {
-    siblings: usize,
-    raw_siblings: usize,
     id: String,
-}
-
-impl MjNavbarExtra {
-    fn new(siblings: usize, raw_siblings: usize, id: String) -> Self {
-        Self {
-            siblings,
-            raw_siblings,
-            id,
-        }
-    }
 }
 
 impl<'element, 'header> Renderer<'element, 'header, MjNavbar, MjNavbarExtra> {
@@ -186,11 +174,11 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_siblings(&mut self, value: usize) {
-        self.extra.siblings = value;
+        self.siblings = value;
     }
 
     fn set_raw_siblings(&mut self, value: usize) {
-        self.extra.raw_siblings = value;
+        self.raw_siblings = value;
     }
 
     fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
@@ -230,7 +218,7 @@ impl<'element, 'header> Render<'element, 'header>
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjNavbar {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         let id = context.generator.next_id();
-        Box::new(Renderer::new(context, self, MjNavbarExtra::new(1, 0, id)))
+        Box::new(Renderer::new(context, self, MjNavbarExtra { id }))
     }
 }
 

--- a/packages/mrml-core/src/mj_navbar/render.rs
+++ b/packages/mrml-core/src/mj_navbar/render.rs
@@ -2,8 +2,11 @@ use super::{MjNavbar, MjNavbarChild, NAME};
 use crate::helper::size::{Pixel, Size};
 use crate::prelude::render::*;
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjNavbarChild {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjNavbarChild {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         match self {
             Self::MjNavbarLink(elt) => elt.renderer(context),
             Self::Comment(elt) => elt.renderer(context),
@@ -15,7 +18,7 @@ struct MjNavbarExtra {
     id: String,
 }
 
-impl<'element, 'header> Renderer<'element, 'header, MjNavbar, MjNavbarExtra> {
+impl<'root> Renderer<'root, MjNavbar, MjNavbarExtra> {
     fn set_style_input<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "none !important")
             .add_style("max-height", "0")
@@ -131,9 +134,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjNavbar, MjNavbarExtra> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjNavbar, MjNavbarExtra>
-{
+impl<'root> Render<'root> for Renderer<'root, MjNavbar, MjNavbarExtra> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "align" => Some("center"),
@@ -151,7 +152,7 @@ impl<'element, 'header> Render<'element, 'header>
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -159,7 +160,7 @@ impl<'element, 'header> Render<'element, 'header>
         Some(NAME)
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -215,8 +216,11 @@ impl<'element, 'header> Render<'element, 'header>
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjNavbar {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjNavbar {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         let id = context.generator.next_id();
         Box::new(Renderer::new(context, self, MjNavbarExtra { id }))
     }

--- a/packages/mrml-core/src/mj_navbar/render.rs
+++ b/packages/mrml-core/src/mj_navbar/render.rs
@@ -2,10 +2,6 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::{MjNavbar, MjNavbarChild, NAME};
-use crate::helper::condition::{
-    END_CONDITIONAL_TAG, END_NEGATION_CONDITIONAL_TAG, START_CONDITIONAL_TAG,
-    START_MSO_NEGATION_CONDITIONAL_TAG,
-};
 use crate::helper::size::{Pixel, Size};
 use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
 
@@ -103,9 +99,9 @@ impl<'e, 'h> MjNavbarRender<'e, 'h> {
             .set_style_ico_close(Tag::new("span"))
             .add_class("mj-menu-icon-close");
 
-        buf.push_str(START_MSO_NEGATION_CONDITIONAL_TAG);
+        buf.start_mso_negation_conditional_tag();
         input.render_closed(buf);
-        buf.push_str(END_NEGATION_CONDITIONAL_TAG);
+        buf.end_negation_conditional_tag();
 
         div.render_open(buf);
         label.render_open(buf);
@@ -204,10 +200,10 @@ impl<'e, 'h> Render<'e, 'h> for MjNavbarRender<'e, 'h> {
         }
 
         div.render_open(buf);
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         table.render_open(buf);
         tr.render_open(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
 
         for child in self.element.children.iter() {
             let mut renderer = child.renderer(Rc::clone(&self.header));
@@ -215,10 +211,10 @@ impl<'e, 'h> Render<'e, 'h> for MjNavbarRender<'e, 'h> {
             renderer.render(opts, buf)?;
         }
 
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         tr.render_close(buf);
         table.render_close(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
         div.render_close(buf);
 
         Ok(())

--- a/packages/mrml-core/src/mj_navbar/render.rs
+++ b/packages/mrml-core/src/mj_navbar/render.rs
@@ -19,13 +19,17 @@ struct MjNavbarExtra {
 }
 
 impl<'root> Renderer<'root, MjNavbar, MjNavbarExtra> {
-    fn set_style_input<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_input<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         tag.add_style("display", "none !important")
             .add_style("max-height", "0")
             .add_style("visibility", "hidden")
     }
 
-    fn set_style_label<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_label<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.add_style("display", "block")
             .add_style("cursor", "pointer")
             .add_style("mso-hide", "all")
@@ -44,7 +48,7 @@ impl<'root> Renderer<'root, MjNavbar, MjNavbarExtra> {
             .maybe_add_style("padding", self.attribute("ico-padding"))
     }
 
-    fn set_style_trigger<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_trigger<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         tag.add_style("display", "none")
             .add_style("max-height", "0px")
             .add_style("max-width", "0px")
@@ -52,12 +56,12 @@ impl<'root> Renderer<'root, MjNavbar, MjNavbarExtra> {
             .add_style("overflow", "hidden")
     }
 
-    fn set_style_ico_close<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_ico_close<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         tag.add_style("display", "none")
             .add_style("mso-hide", "all")
     }
 
-    fn set_style_ico_open<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_ico_open<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         tag.add_style("mso-hide", "all")
     }
 
@@ -103,12 +107,12 @@ impl<'root> Renderer<'root, MjNavbar, MjNavbarExtra> {
 
         span_open.render_open(buf);
         if let Some(attr) = self.attribute("ico-open") {
-            buf.push_str(&attr);
+            buf.push_str(attr);
         }
         span_open.render_close(buf);
         span_close.render_open(buf);
         if let Some(attr) = self.attribute("ico-close") {
-            buf.push_str(&attr);
+            buf.push_str(attr);
         }
         span_close.render_close(buf);
 
@@ -202,7 +206,7 @@ impl<'root> Render<'root> for Renderer<'root, MjNavbar, MjNavbarExtra> {
 
         for child in self.element.children.iter() {
             let mut renderer = child.renderer(self.context());
-            renderer.maybe_add_extra_attribute("navbar-base-url", base_url.clone());
+            renderer.maybe_add_extra_attribute("navbar-base-url", base_url.map(|v| v.to_owned()));
             renderer.render(cursor)?;
         }
 

--- a/packages/mrml-core/src/mj_navbar/render.rs
+++ b/packages/mrml-core/src/mj_navbar/render.rs
@@ -4,8 +4,7 @@ use std::rc::Rc;
 use super::{MjNavbar, MjNavbarChild, NAME};
 use crate::helper::condition::{conditional_tag, mso_negation_conditional_tag};
 use crate::helper::size::{Pixel, Size};
-use crate::helper::tag::Tag;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjNavbarChild {
     fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {

--- a/packages/mrml-core/src/mj_navbar/render.rs
+++ b/packages/mrml-core/src/mj_navbar/render.rs
@@ -24,13 +24,13 @@ struct MjNavbarRender<'e, 'h> {
 }
 
 impl<'e, 'h> MjNavbarRender<'e, 'h> {
-    fn set_style_input(&self, tag: Tag) -> Tag {
+    fn set_style_input<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "none !important")
             .add_style("max-height", "0")
             .add_style("visibility", "hidden")
     }
 
-    fn set_style_label(&self, tag: Tag) -> Tag {
+    fn set_style_label<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "block")
             .add_style("cursor", "pointer")
             .add_style("mso-hide", "all")
@@ -49,7 +49,7 @@ impl<'e, 'h> MjNavbarRender<'e, 'h> {
             .maybe_add_style("padding", self.attribute("ico-padding"))
     }
 
-    fn set_style_trigger(&self, tag: Tag) -> Tag {
+    fn set_style_trigger<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "none")
             .add_style("max-height", "0px")
             .add_style("max-width", "0px")
@@ -57,12 +57,12 @@ impl<'e, 'h> MjNavbarRender<'e, 'h> {
             .add_style("overflow", "hidden")
     }
 
-    fn set_style_ico_close(&self, tag: Tag) -> Tag {
+    fn set_style_ico_close<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "none")
             .add_style("mso-hide", "all")
     }
 
-    fn set_style_ico_open(&self, tag: Tag) -> Tag {
+    fn set_style_ico_open<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("mso-hide", "all")
     }
 

--- a/packages/mrml-core/src/mj_navbar/render.rs
+++ b/packages/mrml-core/src/mj_navbar/render.rs
@@ -5,11 +5,10 @@ use super::{MjNavbar, MjNavbarChild, NAME};
 use crate::helper::condition::{conditional_tag, mso_negation_conditional_tag};
 use crate::helper::size::{Pixel, Size};
 use crate::helper::tag::Tag;
-use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjNavbarChild {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         match self {
             Self::MjNavbarLink(elt) => elt.renderer(header),
             Self::Comment(elt) => elt.renderer(header),
@@ -126,7 +125,7 @@ impl<'e, 'h> MjNavbarRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjNavbarRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjNavbarRender<'e, 'h> {
     fn default_attribute(&self, name: &str) -> Option<&str> {
         match name {
             "align" => Some("center"),
@@ -144,8 +143,8 @@ impl<'e, 'h> Render<'h> for MjNavbarRender<'e, 'h> {
         }
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -201,7 +200,7 @@ impl<'e, 'h> Render<'h> for MjNavbarRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjNavbar {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         let id = header.borrow().next_id();
         Box::new(MjNavbarRender::<'e, 'h> {
             element: self,

--- a/packages/mrml-core/src/mj_navbar_link/render.rs
+++ b/packages/mrml-core/src/mj_navbar_link/render.rs
@@ -16,7 +16,11 @@ impl Default for MjNavbarLinkExtra {
 }
 
 impl<'root> Renderer<'root, MjNavbarLink, MjNavbarLinkExtra> {
-    fn set_style_a<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_a<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.add_style("display", "inline-block")
             .maybe_add_style("color", self.attribute("color"))
             .maybe_add_style("font-family", self.attribute("font-family"))
@@ -34,7 +38,11 @@ impl<'root> Renderer<'root, MjNavbarLink, MjNavbarLinkExtra> {
             .maybe_add_style("padding-left", self.attribute("padding-left"))
     }
 
-    fn set_style_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_td<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.maybe_add_style("padding", self.attribute("padding"))
             .maybe_add_style("padding-top", self.attribute("padding-top"))
             .maybe_add_style("padding-right", self.attribute("padding-right"))

--- a/packages/mrml-core/src/mj_navbar_link/render.rs
+++ b/packages/mrml-core/src/mj_navbar_link/render.rs
@@ -72,7 +72,7 @@ impl<'e, 'h> MjNavbarLinkRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjNavbarLinkRender<'e, 'h> {
-    fn default_attribute(&self, key: &str) -> Option<&str> {
+    fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "color" => Some("#000000"),
             "font-family" => Some("Ubuntu, Helvetica, Arial, sans-serif"),

--- a/packages/mrml-core/src/mj_navbar_link/render.rs
+++ b/packages/mrml-core/src/mj_navbar_link/render.rs
@@ -71,7 +71,7 @@ impl<'e, 'h> MjNavbarLinkRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjNavbarLinkRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjNavbarLinkRender<'e, 'h> {
     fn default_attribute(&self, key: &str) -> Option<&str> {
         match key {
             "color" => Some("#000000"),
@@ -91,12 +91,12 @@ impl<'e, 'h> Render<'h> for MjNavbarLinkRender<'e, 'h> {
         self.extra.insert(key.to_string(), value.to_string());
     }
 
-    fn extra_attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.extra)
+    fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
+        self.extra.get(key).map(|v| v.as_str())
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -124,7 +124,7 @@ impl<'e, 'h> Render<'h> for MjNavbarLinkRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjNavbarLink {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjNavbarLinkRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_navbar_link/render.rs
+++ b/packages/mrml-core/src/mj_navbar_link/render.rs
@@ -5,14 +5,12 @@ use crate::prelude::render::*;
 
 struct MjNavbarLinkExtra {
     attributes: Map<String, String>,
-    container_width: Option<Pixel>,
 }
 
 impl Default for MjNavbarLinkExtra {
     fn default() -> Self {
         Self {
             attributes: Map::new(),
-            container_width: None,
         }
     }
 }
@@ -110,7 +108,7 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn context(&self) -> &'header RenderContext<'header> {

--- a/packages/mrml-core/src/mj_navbar_link/render.rs
+++ b/packages/mrml-core/src/mj_navbar_link/render.rs
@@ -2,7 +2,6 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::{MjNavbarLink, NAME};
-use crate::helper::condition::{END_CONDITIONAL_TAG, START_CONDITIONAL_TAG};
 use crate::helper::size::Pixel;
 use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
@@ -119,13 +118,13 @@ impl<'e, 'h> Render<'e, 'h> for MjNavbarLinkRender<'e, 'h> {
             .set_style_td(Tag::td())
             .maybe_add_suffixed_class(self.attribute("css-class"), "outlook");
 
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         td.render_open(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
         self.render_content(opts, buf)?;
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         td.render_close(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
 
         Ok(())
     }

--- a/packages/mrml-core/src/mj_navbar_link/render.rs
+++ b/packages/mrml-core/src/mj_navbar_link/render.rs
@@ -4,7 +4,7 @@ use crate::prelude::hash::Map;
 use crate::prelude::render::*;
 
 struct MjNavbarLinkRender<'e, 'h> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e MjNavbarLink,
     extra: Map<String, String>,
     container_width: Option<Pixel>,
@@ -47,7 +47,6 @@ impl<'e, 'h> MjNavbarLinkRender<'e, 'h> {
 
     fn render_content(
         &self,
-        opts: &RenderOptions,
         header: &mut VariableHeader,
         buf: &mut RenderBuffer,
     ) -> Result<(), Error> {
@@ -62,8 +61,8 @@ impl<'e, 'h> MjNavbarLinkRender<'e, 'h> {
 
         link.render_open(buf);
         for child in self.element.children.iter() {
-            let renderer = child.renderer(self.header);
-            renderer.render(opts, header, buf)?;
+            let renderer = child.renderer(self.context());
+            renderer.render(header, buf)?;
         }
         link.render_close(buf);
 
@@ -107,16 +106,11 @@ impl<'e, 'h> Render<'e, 'h> for MjNavbarLinkRender<'e, 'h> {
         self.container_width = width;
     }
 
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        self.context
     }
 
-    fn render(
-        &self,
-        opts: &RenderOptions,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
         let font_families = self.attribute("font-family");
         header.maybe_add_font_families(font_families);
 
@@ -127,7 +121,7 @@ impl<'e, 'h> Render<'e, 'h> for MjNavbarLinkRender<'e, 'h> {
         buf.start_conditional_tag();
         td.render_open(buf);
         buf.end_conditional_tag();
-        self.render_content(opts, header, buf)?;
+        self.render_content(header, buf)?;
         buf.start_conditional_tag();
         td.render_close(buf);
         buf.end_conditional_tag();
@@ -137,10 +131,10 @@ impl<'e, 'h> Render<'e, 'h> for MjNavbarLinkRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjNavbarLink {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjNavbarLinkRender::<'e, 'h> {
             element: self,
-            header,
+            context,
             extra: Map::new(),
             container_width: None,
         })

--- a/packages/mrml-core/src/mj_navbar_link/render.rs
+++ b/packages/mrml-core/src/mj_navbar_link/render.rs
@@ -3,11 +3,11 @@ use crate::helper::size::Pixel;
 use crate::prelude::hash::Map;
 use crate::prelude::render::*;
 
-struct MjNavbarLinkExtra {
-    attributes: Map<String, String>,
+struct MjNavbarLinkExtra<'a> {
+    attributes: Map<&'a str, &'a str>,
 }
 
-impl Default for MjNavbarLinkExtra {
+impl<'a> Default for MjNavbarLinkExtra<'a> {
     fn default() -> Self {
         Self {
             attributes: Map::new(),
@@ -15,7 +15,7 @@ impl Default for MjNavbarLinkExtra {
     }
 }
 
-impl<'root> Renderer<'root, MjNavbarLink, MjNavbarLinkExtra> {
+impl<'root> Renderer<'root, MjNavbarLink, MjNavbarLinkExtra<'root>> {
     fn set_style_a<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
     where
         'root: 'a,
@@ -79,7 +79,7 @@ impl<'root> Renderer<'root, MjNavbarLink, MjNavbarLinkExtra> {
     }
 }
 
-impl<'root> Render<'root> for Renderer<'root, MjNavbarLink, MjNavbarLinkExtra> {
+impl<'root> Render<'root> for Renderer<'root, MjNavbarLink, MjNavbarLinkExtra<'root>> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "color" => Some("#000000"),
@@ -95,14 +95,12 @@ impl<'root> Render<'root> for Renderer<'root, MjNavbarLink, MjNavbarLinkExtra> {
         }
     }
 
-    fn add_extra_attribute(&mut self, key: &str, value: &str) {
-        self.extra
-            .attributes
-            .insert(key.to_string(), value.to_string());
+    fn add_extra_attribute(&mut self, key: &'root str, value: &'root str) {
+        self.extra.attributes.insert(key, value);
     }
 
-    fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
-        self.extra.attributes.get(key).map(|v| v.as_str())
+    fn raw_extra_attribute(&self, key: &str) -> Option<&'root str> {
+        self.extra.attributes.get(key).copied()
     }
 
     fn raw_attribute(&self, key: &str) -> Option<&'root str> {

--- a/packages/mrml-core/src/mj_navbar_link/render.rs
+++ b/packages/mrml-core/src/mj_navbar_link/render.rs
@@ -15,7 +15,7 @@ impl Default for MjNavbarLinkExtra {
     }
 }
 
-impl<'element, 'header> Renderer<'element, 'header, MjNavbarLink, MjNavbarLinkExtra> {
+impl<'root> Renderer<'root, MjNavbarLink, MjNavbarLinkExtra> {
     fn set_style_a<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "inline-block")
             .maybe_add_style("color", self.attribute("color"))
@@ -71,9 +71,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjNavbarLink, MjNavbarLinkEx
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjNavbarLink, MjNavbarLinkExtra>
-{
+impl<'root> Render<'root> for Renderer<'root, MjNavbarLink, MjNavbarLinkExtra> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "color" => Some("#000000"),
@@ -99,7 +97,7 @@ impl<'element, 'header> Render<'element, 'header>
         self.extra.attributes.get(key).map(|v| v.as_str())
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -111,7 +109,7 @@ impl<'element, 'header> Render<'element, 'header>
         self.container_width = width;
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -135,8 +133,11 @@ impl<'element, 'header> Render<'element, 'header>
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjNavbarLink {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjNavbarLink {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, MjNavbarLinkExtra::default()))
     }
 }

--- a/packages/mrml-core/src/mj_navbar_link/render.rs
+++ b/packages/mrml-core/src/mj_navbar_link/render.rs
@@ -4,9 +4,8 @@ use std::rc::Rc;
 use super::{MjNavbarLink, NAME};
 use crate::helper::condition::conditional_tag;
 use crate::helper::size::Pixel;
-use crate::helper::tag::Tag;
 use crate::prelude::hash::Map;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 struct MjNavbarLinkRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,

--- a/packages/mrml-core/src/mj_navbar_link/render.rs
+++ b/packages/mrml-core/src/mj_navbar_link/render.rs
@@ -3,14 +3,21 @@ use crate::helper::size::Pixel;
 use crate::prelude::hash::Map;
 use crate::prelude::render::*;
 
-struct MjNavbarLinkRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e MjNavbarLink,
-    extra: Map<String, String>,
+struct MjNavbarLinkExtra {
+    attributes: Map<String, String>,
     container_width: Option<Pixel>,
 }
 
-impl<'e, 'h> MjNavbarLinkRender<'e, 'h> {
+impl Default for MjNavbarLinkExtra {
+    fn default() -> Self {
+        Self {
+            attributes: Map::new(),
+            container_width: None,
+        }
+    }
+}
+
+impl<'element, 'header> Renderer<'element, 'header, MjNavbarLink, MjNavbarLinkExtra> {
     fn set_style_a<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "inline-block")
             .maybe_add_style("color", self.attribute("color"))
@@ -66,7 +73,9 @@ impl<'e, 'h> MjNavbarLinkRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'e, 'h> for MjNavbarLinkRender<'e, 'h> {
+impl<'element, 'header> Render<'element, 'header>
+    for Renderer<'element, 'header, MjNavbarLink, MjNavbarLinkExtra>
+{
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "color" => Some("#000000"),
@@ -83,14 +92,16 @@ impl<'e, 'h> Render<'e, 'h> for MjNavbarLinkRender<'e, 'h> {
     }
 
     fn add_extra_attribute(&mut self, key: &str, value: &str) {
-        self.extra.insert(key.to_string(), value.to_string());
+        self.extra
+            .attributes
+            .insert(key.to_string(), value.to_string());
     }
 
     fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
-        self.extra.get(key).map(|v| v.as_str())
+        self.extra.attributes.get(key).map(|v| v.as_str())
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -99,10 +110,10 @@ impl<'e, 'h> Render<'e, 'h> for MjNavbarLinkRender<'e, 'h> {
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.container_width = width;
+        self.extra.container_width = width;
     }
 
-    fn context(&self) -> &'h RenderContext<'h> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
@@ -128,11 +139,6 @@ impl<'e, 'h> Render<'e, 'h> for MjNavbarLinkRender<'e, 'h> {
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjNavbarLink {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjNavbarLinkRender::<'e, 'h> {
-            element: self,
-            context,
-            extra: Map::new(),
-            container_width: None,
-        })
+        Box::new(Renderer::new(context, self, MjNavbarLinkExtra::default()))
     }
 }

--- a/packages/mrml-core/src/mj_navbar_link/render.rs
+++ b/packages/mrml-core/src/mj_navbar_link/render.rs
@@ -45,11 +45,7 @@ impl<'e, 'h> MjNavbarLinkRender<'e, 'h> {
         })
     }
 
-    fn render_content(
-        &self,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_content(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let link = self
             .set_style_a(Tag::new("a"))
             .add_class("mj-link")
@@ -59,12 +55,12 @@ impl<'e, 'h> MjNavbarLinkRender<'e, 'h> {
             .maybe_add_attribute("target", self.attribute("target"))
             .maybe_add_attribute("name", self.attribute("name"));
 
-        link.render_open(buf);
+        link.render_open(&mut cursor.buffer);
         for child in self.element.children.iter() {
             let renderer = child.renderer(self.context());
-            renderer.render(header, buf)?;
+            renderer.render(cursor)?;
         }
-        link.render_close(buf);
+        link.render_close(&mut cursor.buffer);
 
         Ok(())
     }
@@ -110,21 +106,21 @@ impl<'e, 'h> Render<'e, 'h> for MjNavbarLinkRender<'e, 'h> {
         self.context
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let font_families = self.attribute("font-family");
-        header.maybe_add_font_families(font_families);
+        cursor.header.maybe_add_font_families(font_families);
 
         let td = self
             .set_style_td(Tag::td())
             .maybe_add_suffixed_class(self.attribute("css-class"), "outlook");
 
-        buf.start_conditional_tag();
-        td.render_open(buf);
-        buf.end_conditional_tag();
-        self.render_content(header, buf)?;
-        buf.start_conditional_tag();
-        td.render_close(buf);
-        buf.end_conditional_tag();
+        cursor.buffer.start_conditional_tag();
+        td.render_open(&mut cursor.buffer);
+        cursor.buffer.end_conditional_tag();
+        self.render_content(cursor)?;
+        cursor.buffer.start_conditional_tag();
+        td.render_close(&mut cursor.buffer);
+        cursor.buffer.end_conditional_tag();
 
         Ok(())
     }

--- a/packages/mrml-core/src/mj_navbar_link/render.rs
+++ b/packages/mrml-core/src/mj_navbar_link/render.rs
@@ -14,7 +14,7 @@ struct MjNavbarLinkRender<'e, 'h> {
 }
 
 impl<'e, 'h> MjNavbarLinkRender<'e, 'h> {
-    fn set_style_a(&self, tag: Tag) -> Tag {
+    fn set_style_a<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("display", "inline-block")
             .maybe_add_style("color", self.attribute("color"))
             .maybe_add_style("font-family", self.attribute("font-family"))
@@ -32,7 +32,7 @@ impl<'e, 'h> MjNavbarLinkRender<'e, 'h> {
             .maybe_add_style("padding-left", self.attribute("padding-left"))
     }
 
-    fn set_style_td(&self, tag: Tag) -> Tag {
+    fn set_style_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("padding", self.attribute("padding"))
             .maybe_add_style("padding-top", self.attribute("padding-top"))
             .maybe_add_style("padding-right", self.attribute("padding-right"))

--- a/packages/mrml-core/src/mj_raw/render.rs
+++ b/packages/mrml-core/src/mj_raw/render.rs
@@ -31,7 +31,7 @@ impl<'e, 'h> Render<'e, 'h> for MjRawRender<'e, 'h> {
         self.container_width = width;
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let siblings = self.element.children.len();
         for (index, child) in self.element.children.iter().enumerate() {
             let mut renderer = child.renderer(self.context());
@@ -39,7 +39,7 @@ impl<'e, 'h> Render<'e, 'h> for MjRawRender<'e, 'h> {
             renderer.set_siblings(siblings);
             renderer.set_raw_siblings(siblings);
             renderer.set_container_width(self.container_width.clone());
-            renderer.render(header, buf)?;
+            renderer.render(cursor)?;
         }
         Ok(())
     }

--- a/packages/mrml-core/src/mj_raw/render.rs
+++ b/packages/mrml-core/src/mj_raw/render.rs
@@ -6,7 +6,7 @@ use crate::helper::size::Pixel;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjRawChild {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         match self {
             Self::Comment(elt) => elt.renderer(header),
             Self::Node(elt) => elt.renderer(header),
@@ -21,7 +21,7 @@ struct MjRawRender<'e, 'h> {
     container_width: Option<Pixel>,
 }
 
-impl<'e, 'h> Render<'h> for MjRawRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjRawRender<'e, 'h> {
     fn tag(&self) -> Option<&str> {
         Some(NAME)
     }
@@ -51,7 +51,7 @@ impl<'e, 'h> Render<'h> for MjRawRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjRaw {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjRawRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_raw/render.rs
+++ b/packages/mrml-core/src/mj_raw/render.rs
@@ -2,8 +2,11 @@ use super::{MjRaw, MjRawChild, NAME};
 use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjRawChild {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjRawChild {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         match self {
             Self::Comment(elt) => elt.renderer(context),
             Self::Node(elt) => elt.renderer(context),
@@ -12,12 +15,12 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjRawChild {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjRaw, ()> {
+impl<'root> Render<'root> for Renderer<'root, MjRaw, ()> {
     fn tag(&self) -> Option<&str> {
         Some(NAME)
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -39,8 +42,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjRaw {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjRaw {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/mj_raw/render.rs
+++ b/packages/mrml-core/src/mj_raw/render.rs
@@ -3,17 +3,17 @@ use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjRawChild {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         match self {
-            Self::Comment(elt) => elt.renderer(header),
-            Self::Node(elt) => elt.renderer(header),
-            Self::Text(elt) => elt.renderer(header),
+            Self::Comment(elt) => elt.renderer(context),
+            Self::Node(elt) => elt.renderer(context),
+            Self::Text(elt) => elt.renderer(context),
         }
     }
 }
 
 struct MjRawRender<'e, 'h> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e MjRaw,
     container_width: Option<Pixel>,
 }
@@ -23,38 +23,33 @@ impl<'e, 'h> Render<'e, 'h> for MjRawRender<'e, 'h> {
         Some(NAME)
     }
 
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        self.context
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
         self.container_width = width;
     }
 
-    fn render(
-        &self,
-        opts: &RenderOptions,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
         let siblings = self.element.children.len();
         for (index, child) in self.element.children.iter().enumerate() {
-            let mut renderer = child.renderer(self.header);
+            let mut renderer = child.renderer(self.context());
             renderer.set_index(index);
             renderer.set_siblings(siblings);
             renderer.set_raw_siblings(siblings);
             renderer.set_container_width(self.container_width.clone());
-            renderer.render(opts, header, buf)?;
+            renderer.render(header, buf)?;
         }
         Ok(())
     }
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjRaw {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjRawRender::<'e, 'h> {
             element: self,
-            header,
+            context,
             container_width: None,
         })
     }

--- a/packages/mrml-core/src/mj_raw/render.rs
+++ b/packages/mrml-core/src/mj_raw/render.rs
@@ -12,23 +12,24 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjRawChild {
     }
 }
 
-struct MjRawRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e MjRaw,
+#[derive(Default)]
+struct MjRawExtra {
     container_width: Option<Pixel>,
 }
 
-impl<'e, 'h> Render<'e, 'h> for MjRawRender<'e, 'h> {
+impl<'element, 'header> Render<'element, 'header>
+    for Renderer<'element, 'header, MjRaw, MjRawExtra>
+{
     fn tag(&self) -> Option<&str> {
         Some(NAME)
     }
 
-    fn context(&self) -> &'h RenderContext<'h> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.container_width = width;
+        self.extra.container_width = width;
     }
 
     fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
@@ -38,7 +39,7 @@ impl<'e, 'h> Render<'e, 'h> for MjRawRender<'e, 'h> {
             renderer.set_index(index);
             renderer.set_siblings(siblings);
             renderer.set_raw_siblings(siblings);
-            renderer.set_container_width(self.container_width.clone());
+            renderer.set_container_width(self.extra.container_width.clone());
             renderer.render(cursor)?;
         }
         Ok(())
@@ -47,11 +48,7 @@ impl<'e, 'h> Render<'e, 'h> for MjRawRender<'e, 'h> {
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjRaw {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjRawRender::<'e, 'h> {
-            element: self,
-            context,
-            container_width: None,
-        })
+        Box::new(Renderer::new(context, self, MjRawExtra::default()))
     }
 }
 

--- a/packages/mrml-core/src/mj_raw/render.rs
+++ b/packages/mrml-core/src/mj_raw/render.rs
@@ -1,12 +1,9 @@
-use std::cell::{Ref, RefCell};
-use std::rc::Rc;
-
 use super::{MjRaw, MjRawChild, NAME};
 use crate::helper::size::Pixel;
-use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable};
+use crate::prelude::render::*;
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjRawChild {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         match self {
             Self::Comment(elt) => elt.renderer(header),
             Self::Node(elt) => elt.renderer(header),
@@ -16,7 +13,7 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjRawChild {
 }
 
 struct MjRawRender<'e, 'h> {
-    header: Rc<RefCell<Header<'h>>>,
+    header: &'h Header<'h>,
     element: &'e MjRaw,
     container_width: Option<Pixel>,
 }
@@ -26,30 +23,35 @@ impl<'e, 'h> Render<'e, 'h> for MjRawRender<'e, 'h> {
         Some(NAME)
     }
 
-    fn header(&self) -> Ref<Header<'h>> {
-        self.header.borrow()
+    fn header(&self) -> &'h Header<'h> {
+        self.header
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
         self.container_width = width;
     }
 
-    fn render(&self, opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(
+        &self,
+        opts: &RenderOptions,
+        header: &mut VariableHeader,
+        buf: &mut RenderBuffer,
+    ) -> Result<(), Error> {
         let siblings = self.element.children.len();
         for (index, child) in self.element.children.iter().enumerate() {
-            let mut renderer = child.renderer(Rc::clone(&self.header));
+            let mut renderer = child.renderer(self.header);
             renderer.set_index(index);
             renderer.set_siblings(siblings);
             renderer.set_raw_siblings(siblings);
             renderer.set_container_width(self.container_width.clone());
-            renderer.render(opts, buf)?;
+            renderer.render(opts, header, buf)?;
         }
         Ok(())
     }
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjRaw {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjRawRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_raw/render.rs
+++ b/packages/mrml-core/src/mj_raw/render.rs
@@ -12,14 +12,7 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjRawChild {
     }
 }
 
-#[derive(Default)]
-struct MjRawExtra {
-    container_width: Option<Pixel>,
-}
-
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjRaw, MjRawExtra>
-{
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjRaw, ()> {
     fn tag(&self) -> Option<&str> {
         Some(NAME)
     }
@@ -29,7 +22,7 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
@@ -39,7 +32,7 @@ impl<'element, 'header> Render<'element, 'header>
             renderer.set_index(index);
             renderer.set_siblings(siblings);
             renderer.set_raw_siblings(siblings);
-            renderer.set_container_width(self.extra.container_width.clone());
+            renderer.set_container_width(self.container_width.clone());
             renderer.render(cursor)?;
         }
         Ok(())
@@ -48,7 +41,7 @@ impl<'element, 'header> Render<'element, 'header>
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjRaw {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(Renderer::new(context, self, MjRawExtra::default()))
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_section/render.rs
+++ b/packages/mrml-core/src/mj_section/render.rs
@@ -5,8 +5,7 @@ use std::rc::Rc;
 use super::{MjSection, NAME};
 use crate::helper::condition::{conditional_tag, END_CONDITIONAL_TAG, START_CONDITIONAL_TAG};
 use crate::helper::size::{Percent, Pixel};
-use crate::helper::tag::Tag;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 fn is_horizontal_position(value: &str) -> bool {
     value == "left" || value == "right" || value == "center"

--- a/packages/mrml-core/src/mj_section/render.rs
+++ b/packages/mrml-core/src/mj_section/render.rs
@@ -79,7 +79,7 @@ pub trait WithMjSectionBackground<'e, 'h>: Render<'e, 'h> {
         }
     }
 
-    fn set_background_style(&self, tag: Tag) -> Tag {
+    fn set_background_style<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         if self.has_background() {
             tag.maybe_add_style("background", self.get_background())
                 .add_style("background-position", self.get_background_position_str())
@@ -240,7 +240,7 @@ pub trait SectionLikeRender<'e, 'h>: WithMjSectionBackground<'e, 'h> {
         Ok(())
     }
 
-    fn set_style_section_div(&self, tag: Tag) -> Tag {
+    fn set_style_section_div<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         let base = if self.is_full_width() {
             tag
         } else {
@@ -334,12 +334,12 @@ pub trait SectionLikeRender<'e, 'h>: WithMjSectionBackground<'e, 'h> {
         Ok(())
     }
 
-    fn set_style_section_inner_div(&self, tag: Tag) -> Tag {
+    fn set_style_section_inner_div<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("line-height", "0")
             .add_style("font-size", "0")
     }
 
-    fn set_style_section_table(&self, tag: Tag) -> Tag {
+    fn set_style_section_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         let base = if self.is_full_width() {
             tag
         } else {
@@ -349,7 +349,7 @@ pub trait SectionLikeRender<'e, 'h>: WithMjSectionBackground<'e, 'h> {
             .maybe_add_style("border-radius", self.attribute("border-radius"))
     }
 
-    fn set_style_section_td(&self, tag: Tag) -> Tag {
+    fn set_style_section_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("border", self.attribute("border"))
             .maybe_add_style("border-bottom", self.attribute("border-bottom"))
             .maybe_add_style("border-left", self.attribute("border-left"))
@@ -418,7 +418,7 @@ pub trait SectionLikeRender<'e, 'h>: WithMjSectionBackground<'e, 'h> {
         Ok(())
     }
 
-    fn set_style_table_full_width(&self, tag: Tag) -> Tag {
+    fn set_style_table_full_width<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         let base = if self.is_full_width() {
             self.set_background_style(tag)
         } else {

--- a/packages/mrml-core/src/mj_section/render.rs
+++ b/packages/mrml-core/src/mj_section/render.rs
@@ -458,8 +458,8 @@ pub trait SectionLikeRender<'e, 'h>: WithMjSectionBackground<'e, 'h> {
         td.render_open(buf);
         //
         if self.has_background() {
-            self.render_with_background(buf, |buf: &mut String| {
-                self.render_wrap(buf, |buf: &mut String| {
+            self.render_with_background(buf, |buf| {
+                self.render_wrap(buf, |buf| {
                     buf.push_str(END_CONDITIONAL_TAG);
                     self.render_section(opts, buf)?;
                     buf.push_str(START_CONDITIONAL_TAG);
@@ -467,7 +467,7 @@ pub trait SectionLikeRender<'e, 'h>: WithMjSectionBackground<'e, 'h> {
                 })
             })?;
         } else {
-            self.render_wrap(buf, |buf: &mut String| {
+            self.render_wrap(buf, |buf| {
                 buf.push_str(END_CONDITIONAL_TAG);
                 self.render_section(opts, buf)?;
                 buf.push_str(START_CONDITIONAL_TAG);
@@ -484,11 +484,9 @@ pub trait SectionLikeRender<'e, 'h>: WithMjSectionBackground<'e, 'h> {
     }
 
     fn render_simple(&self, opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
-        self.render_wrap(buf, |buf: &mut String| {
+        self.render_wrap(buf, |buf| {
             if self.has_background() {
-                self.render_with_background(buf, |buf: &mut String| {
-                    self.render_section(opts, buf)
-                })?;
+                self.render_with_background(buf, |buf| self.render_section(opts, buf))?;
             } else {
                 buf.push_str(END_CONDITIONAL_TAG);
                 self.render_section(opts, buf)?;

--- a/packages/mrml-core/src/mj_section/render.rs
+++ b/packages/mrml-core/src/mj_section/render.rs
@@ -449,7 +449,7 @@ impl<'e, 'h> SectionLikeRender<'e, 'h> for MjSectionRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjSectionRender<'e, 'h> {
-    fn default_attribute(&self, name: &str) -> Option<&str> {
+    fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "background-position" => Some("top center"),
             "background-repeat" => Some("repeat"),

--- a/packages/mrml-core/src/mj_section/render.rs
+++ b/packages/mrml-core/src/mj_section/render.rs
@@ -479,30 +479,23 @@ pub trait SectionLikeRender<'element, 'header>: WithMjSectionBackground<'element
     }
 }
 
-#[derive(Default)]
-struct MjSectionExtra {
-    container_width: Option<Pixel>,
-}
-
 impl<'element, 'header> WithMjSectionBackground<'element, 'header>
-    for Renderer<'element, 'header, MjSection, MjSectionExtra>
+    for Renderer<'element, 'header, MjSection, ()>
 {
 }
 impl<'element, 'header> SectionLikeRender<'element, 'header>
-    for Renderer<'element, 'header, MjSection, MjSectionExtra>
+    for Renderer<'element, 'header, MjSection, ()>
 {
     fn children(&self) -> &Vec<crate::mj_body::MjBodyChild> {
         &self.element.children
     }
 
     fn container_width(&self) -> &Option<Pixel> {
-        &self.extra.container_width
+        &self.container_width
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjSection, MjSectionExtra>
-{
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjSection, ()> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "background-position" => Some("top center"),
@@ -529,7 +522,7 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
@@ -543,7 +536,7 @@ impl<'element, 'header> Render<'element, 'header>
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSection {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(Renderer::new(context, self, MjSectionExtra::default()))
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_section/render.rs
+++ b/packages/mrml-core/src/mj_section/render.rs
@@ -3,7 +3,6 @@ use std::convert::TryFrom;
 use std::rc::Rc;
 
 use super::{MjSection, NAME};
-use crate::helper::condition::{END_CONDITIONAL_TAG, START_CONDITIONAL_TAG};
 use crate::helper::size::{Percent, Pixel};
 use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
 
@@ -232,9 +231,9 @@ pub trait SectionLikeRender<'e, 'h>: WithMjSectionBackground<'e, 'h> {
         vrect.render_open(buf);
         vfill.render_closed(buf);
         vtextbox.render_open(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
         content(buf)?;
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         vtextbox.render_close(buf);
         vrect.render_close(buf);
 
@@ -279,7 +278,7 @@ pub trait SectionLikeRender<'e, 'h>: WithMjSectionBackground<'e, 'h> {
             .add_style("font-size", "0px")
             .add_style("mso-line-height-rule", "exactly");
 
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         table.render_open(buf);
         tr.render_open(buf);
         td.render_open(buf);
@@ -287,7 +286,7 @@ pub trait SectionLikeRender<'e, 'h>: WithMjSectionBackground<'e, 'h> {
         td.render_close(buf);
         tr.render_close(buf);
         table.render_close(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
 
         Ok(())
     }
@@ -316,18 +315,18 @@ pub trait SectionLikeRender<'e, 'h>: WithMjSectionBackground<'e, 'h> {
             renderer.set_raw_siblings(raw_siblings);
             renderer.set_container_width(self.container_width().clone());
             if child.is_raw() {
-                buf.push_str(END_CONDITIONAL_TAG);
+                buf.end_conditional_tag();
                 renderer.render(opts, buf)?;
-                buf.push_str(START_CONDITIONAL_TAG);
+                buf.start_conditional_tag();
             } else {
                 let td = renderer
                     .set_style("td-outlook", Tag::td())
                     .maybe_add_attribute("align", renderer.attribute("align"))
                     .maybe_add_suffixed_class(renderer.attribute("css-class"), "outlook");
                 td.render_open(buf);
-                buf.push_str(END_CONDITIONAL_TAG);
+                buf.end_conditional_tag();
                 renderer.render(opts, buf)?;
-                buf.push_str(START_CONDITIONAL_TAG);
+                buf.start_conditional_tag();
                 td.render_close(buf);
             }
         }
@@ -402,11 +401,11 @@ pub trait SectionLikeRender<'e, 'h>: WithMjSectionBackground<'e, 'h> {
         tbody.render_open(buf);
         tr.render_open(buf);
         td.render_open(buf);
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         inner_table.render_open(buf);
         self.render_wrapped_children(opts, buf)?;
         inner_table.render_close(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
         td.render_close(buf);
         tr.render_close(buf);
         tbody.render_close(buf);
@@ -460,17 +459,17 @@ pub trait SectionLikeRender<'e, 'h>: WithMjSectionBackground<'e, 'h> {
         if self.has_background() {
             self.render_with_background(buf, |buf| {
                 self.render_wrap(buf, |buf| {
-                    buf.push_str(END_CONDITIONAL_TAG);
+                    buf.end_conditional_tag();
                     self.render_section(opts, buf)?;
-                    buf.push_str(START_CONDITIONAL_TAG);
+                    buf.start_conditional_tag();
                     Ok(())
                 })
             })?;
         } else {
             self.render_wrap(buf, |buf| {
-                buf.push_str(END_CONDITIONAL_TAG);
+                buf.end_conditional_tag();
                 self.render_section(opts, buf)?;
-                buf.push_str(START_CONDITIONAL_TAG);
+                buf.start_conditional_tag();
                 Ok(())
             })?;
         }
@@ -488,9 +487,9 @@ pub trait SectionLikeRender<'e, 'h>: WithMjSectionBackground<'e, 'h> {
             if self.has_background() {
                 self.render_with_background(buf, |buf| self.render_section(opts, buf))?;
             } else {
-                buf.push_str(END_CONDITIONAL_TAG);
+                buf.end_conditional_tag();
                 self.render_section(opts, buf)?;
-                buf.push_str(START_CONDITIONAL_TAG);
+                buf.start_conditional_tag();
             }
             Ok(())
         })

--- a/packages/mrml-core/src/mj_section/render.rs
+++ b/packages/mrml-core/src/mj_section/render.rs
@@ -12,7 +12,7 @@ fn is_vertical_position(value: &str) -> bool {
     value == "top" || value == "bottom" || value == "center"
 }
 
-pub trait WithMjSectionBackground<'element, 'header>: Render<'element, 'header> {
+pub trait WithMjSectionBackground<'root>: Render<'root> {
     fn has_background(&self) -> bool {
         self.attribute_exists("background-url")
     }
@@ -191,7 +191,7 @@ pub trait WithMjSectionBackground<'element, 'header>: Render<'element, 'header> 
     }
 }
 
-pub trait SectionLikeRender<'element, 'header>: WithMjSectionBackground<'element, 'header> {
+pub trait SectionLikeRender<'root>: WithMjSectionBackground<'root> {
     fn container_width(&self) -> &Option<Pixel>;
     fn children(&self) -> &Vec<crate::mj_body::MjBodyChild>;
 
@@ -479,13 +479,8 @@ pub trait SectionLikeRender<'element, 'header>: WithMjSectionBackground<'element
     }
 }
 
-impl<'element, 'header> WithMjSectionBackground<'element, 'header>
-    for Renderer<'element, 'header, MjSection, ()>
-{
-}
-impl<'element, 'header> SectionLikeRender<'element, 'header>
-    for Renderer<'element, 'header, MjSection, ()>
-{
+impl<'root> WithMjSectionBackground<'root> for Renderer<'root, MjSection, ()> {}
+impl<'root> SectionLikeRender<'root> for Renderer<'root, MjSection, ()> {
     fn children(&self) -> &Vec<crate::mj_body::MjBodyChild> {
         &self.element.children
     }
@@ -495,7 +490,7 @@ impl<'element, 'header> SectionLikeRender<'element, 'header>
     }
 }
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjSection, ()> {
+impl<'root> Render<'root> for Renderer<'root, MjSection, ()> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "background-position" => Some("top center"),
@@ -509,7 +504,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -517,7 +512,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         Some(NAME)
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -534,8 +529,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSection {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjSection {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/mj_social/render.rs
+++ b/packages/mrml-core/src/mj_social/render.rs
@@ -4,8 +4,7 @@ use std::rc::Rc;
 use super::{MjSocial, MjSocialChild, NAME};
 use crate::helper::condition::conditional_tag;
 use crate::helper::size::{Pixel, Size};
-use crate::helper::tag::Tag;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSocialChild {
     fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {

--- a/packages/mrml-core/src/mj_social/render.rs
+++ b/packages/mrml-core/src/mj_social/render.rs
@@ -42,21 +42,7 @@ const EXTRA_CHILD_KEY: [&str; 13] = [
     "text-decoration",
 ];
 
-struct MjSocialExtra {
-    siblings: usize,
-    raw_siblings: usize,
-}
-
-impl MjSocialExtra {
-    fn new(siblings: usize, raw_siblings: usize) -> Self {
-        Self {
-            siblings,
-            raw_siblings,
-        }
-    }
-}
-
-impl<'element, 'header> Renderer<'element, 'header, MjSocial, MjSocialExtra> {
+impl<'element, 'header> Renderer<'element, 'header, MjSocial, ()> {
     fn set_style_table_vertical<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("margin", "0px")
     }
@@ -141,9 +127,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjSocial, MjSocialExtra> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjSocial, MjSocialExtra>
-{
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjSocial, ()> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "align" => Some("center"),
@@ -183,11 +167,11 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_siblings(&mut self, value: usize) {
-        self.extra.siblings = value;
+        self.siblings = value;
     }
 
     fn set_raw_siblings(&mut self, value: usize) {
-        self.extra.raw_siblings = value;
+        self.raw_siblings = value;
     }
 
     fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
@@ -204,7 +188,7 @@ impl<'element, 'header> Render<'element, 'header>
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSocial {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(Renderer::new(context, self, MjSocialExtra::new(1, 0)))
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_social/render.rs
+++ b/packages/mrml-core/src/mj_social/render.rs
@@ -2,7 +2,6 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::{MjSocial, MjSocialChild, NAME};
-use crate::helper::condition::{END_CONDITIONAL_TAG, START_CONDITIONAL_TAG};
 use crate::helper::size::{Pixel, Size};
 use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
 
@@ -86,15 +85,15 @@ impl<'e, 'h> MjSocialRender<'e, 'h> {
         let inner_tbody = Tag::tbody();
         let child_attributes = self.build_child_attributes();
 
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         table.render_open(buf);
         tr.render_open(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
 
         for (index, child) in self.element.children.iter().enumerate() {
-            buf.push_str(START_CONDITIONAL_TAG);
+            buf.start_conditional_tag();
             td.render_open(buf);
-            buf.push_str(END_CONDITIONAL_TAG);
+            buf.end_conditional_tag();
             inner_table.render_open(buf);
             inner_tbody.render_open(buf);
             let mut renderer = child.renderer(Rc::clone(&self.header));
@@ -105,15 +104,15 @@ impl<'e, 'h> MjSocialRender<'e, 'h> {
             renderer.render(opts, buf)?;
             inner_tbody.render_close(buf);
             inner_table.render_close(buf);
-            buf.push_str(START_CONDITIONAL_TAG);
+            buf.start_conditional_tag();
             td.render_close(buf);
-            buf.push_str(END_CONDITIONAL_TAG);
+            buf.end_conditional_tag();
         }
 
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         tr.render_close(buf);
         table.render_close(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
         Ok(())
     }
 

--- a/packages/mrml-core/src/mj_social/render.rs
+++ b/packages/mrml-core/src/mj_social/render.rs
@@ -46,7 +46,7 @@ const EXTRA_CHILD_KEY: [&str; 13] = [
 ];
 
 impl<'root> Renderer<'root, MjSocial, ()> {
-    fn set_style_table_vertical<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_table_vertical<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         tag.add_style("margin", "0px")
     }
 
@@ -56,7 +56,7 @@ impl<'root> Renderer<'root, MjSocial, ()> {
             .unwrap_or(true)
     }
 
-    fn build_child_attributes(&self) -> Vec<(&str, String)> {
+    fn build_child_attributes(&self) -> Vec<(&str, &str)> {
         EXTRA_CONTAINER_KEY
             .iter()
             .zip(EXTRA_CHILD_KEY.iter())

--- a/packages/mrml-core/src/mj_social/render.rs
+++ b/packages/mrml-core/src/mj_social/render.rs
@@ -2,8 +2,11 @@ use super::{MjSocial, MjSocialChild, NAME};
 use crate::helper::size::{Pixel, Size};
 use crate::prelude::render::*;
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSocialChild {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjSocialChild {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         match self {
             Self::MjSocialElement(elt) => elt.renderer(context),
             Self::Comment(elt) => elt.renderer(context),
@@ -42,7 +45,7 @@ const EXTRA_CHILD_KEY: [&str; 13] = [
     "text-decoration",
 ];
 
-impl<'element, 'header> Renderer<'element, 'header, MjSocial, ()> {
+impl<'root> Renderer<'root, MjSocial, ()> {
     fn set_style_table_vertical<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("margin", "0px")
     }
@@ -127,7 +130,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjSocial, ()> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjSocial, ()> {
+impl<'root> Render<'root> for Renderer<'root, MjSocial, ()> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "align" => Some("center"),
@@ -144,7 +147,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -152,7 +155,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         Some(NAME)
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -186,8 +189,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSocial {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjSocial {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/mj_social/render.rs
+++ b/packages/mrml-core/src/mj_social/render.rs
@@ -124,7 +124,7 @@ impl<'e, 'h> MjSocialRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjSocialRender<'e, 'h> {
-    fn default_attribute(&self, name: &str) -> Option<&str> {
+    fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "align" => Some("center"),
             "border-radius" => Some("3px"),

--- a/packages/mrml-core/src/mj_social/render.rs
+++ b/packages/mrml-core/src/mj_social/render.rs
@@ -71,11 +71,7 @@ impl<'e, 'h> MjSocialRender<'e, 'h> {
             .collect::<Vec<_>>()
     }
 
-    fn render_horizontal(
-        &self,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_horizontal(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let table = Tag::table_presentation().maybe_add_attribute("align", self.attribute("align"));
         let tr = Tag::tr();
         let td = Tag::td();
@@ -86,58 +82,54 @@ impl<'e, 'h> MjSocialRender<'e, 'h> {
         let inner_tbody = Tag::tbody();
         let child_attributes = self.build_child_attributes();
 
-        buf.start_conditional_tag();
-        table.render_open(buf);
-        tr.render_open(buf);
-        buf.end_conditional_tag();
+        cursor.buffer.start_conditional_tag();
+        table.render_open(&mut cursor.buffer);
+        tr.render_open(&mut cursor.buffer);
+        cursor.buffer.end_conditional_tag();
 
         for (index, child) in self.element.children.iter().enumerate() {
-            buf.start_conditional_tag();
-            td.render_open(buf);
-            buf.end_conditional_tag();
-            inner_table.render_open(buf);
-            inner_tbody.render_open(buf);
+            cursor.buffer.start_conditional_tag();
+            td.render_open(&mut cursor.buffer);
+            cursor.buffer.end_conditional_tag();
+            inner_table.render_open(&mut cursor.buffer);
+            inner_tbody.render_open(&mut cursor.buffer);
             let mut renderer = child.renderer(self.context());
             renderer.set_index(index);
             child_attributes.iter().for_each(|(key, value)| {
                 renderer.add_extra_attribute(key, value);
             });
-            renderer.render(header, buf)?;
-            inner_tbody.render_close(buf);
-            inner_table.render_close(buf);
-            buf.start_conditional_tag();
-            td.render_close(buf);
-            buf.end_conditional_tag();
+            renderer.render(cursor)?;
+            inner_tbody.render_close(&mut cursor.buffer);
+            inner_table.render_close(&mut cursor.buffer);
+            cursor.buffer.start_conditional_tag();
+            td.render_close(&mut cursor.buffer);
+            cursor.buffer.end_conditional_tag();
         }
 
-        buf.start_conditional_tag();
-        tr.render_close(buf);
-        table.render_close(buf);
-        buf.end_conditional_tag();
+        cursor.buffer.start_conditional_tag();
+        tr.render_close(&mut cursor.buffer);
+        table.render_close(&mut cursor.buffer);
+        cursor.buffer.end_conditional_tag();
         Ok(())
     }
 
-    fn render_vertical(
-        &self,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_vertical(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let table = self.set_style_table_vertical(Tag::table_presentation());
         let tbody = Tag::tbody();
         let child_attributes = self.build_child_attributes();
 
-        table.render_open(buf);
-        tbody.render_open(buf);
+        table.render_open(&mut cursor.buffer);
+        tbody.render_open(&mut cursor.buffer);
         for (index, child) in self.element.children.iter().enumerate() {
             let mut renderer = child.renderer(self.context());
             renderer.set_index(index);
             child_attributes.iter().for_each(|(key, value)| {
                 renderer.add_extra_attribute(key, value);
             });
-            renderer.render(header, buf)?;
+            renderer.render(cursor)?;
         }
-        tbody.render_close(buf);
-        table.render_close(buf);
+        tbody.render_close(&mut cursor.buffer);
+        table.render_close(&mut cursor.buffer);
 
         Ok(())
     }
@@ -190,14 +182,14 @@ impl<'e, 'h> Render<'e, 'h> for MjSocialRender<'e, 'h> {
         self.raw_siblings = value;
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let font_families = self.attribute("font-family").unwrap_or_default(); // never happens
-        header.add_font_families(font_families);
+        cursor.header.add_font_families(font_families);
 
         if self.is_horizontal() {
-            self.render_horizontal(header, buf)
+            self.render_horizontal(cursor)
         } else {
-            self.render_vertical(header, buf)
+            self.render_vertical(cursor)
         }
     }
 }

--- a/packages/mrml-core/src/mj_social/render.rs
+++ b/packages/mrml-core/src/mj_social/render.rs
@@ -54,7 +54,7 @@ struct MjSocialRender<'e, 'h> {
 }
 
 impl<'e, 'h> MjSocialRender<'e, 'h> {
-    fn set_style_table_vertical(&self, tag: Tag) -> Tag {
+    fn set_style_table_vertical<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("margin", "0px")
     }
 

--- a/packages/mrml-core/src/mj_social/render.rs
+++ b/packages/mrml-core/src/mj_social/render.rs
@@ -43,7 +43,6 @@ const EXTRA_CHILD_KEY: [&str; 13] = [
 ];
 
 struct MjSocialExtra {
-    container_width: Option<Pixel>,
     siblings: usize,
     raw_siblings: usize,
 }
@@ -51,7 +50,6 @@ struct MjSocialExtra {
 impl MjSocialExtra {
     fn new(siblings: usize, raw_siblings: usize) -> Self {
         Self {
-            container_width: None,
             siblings,
             raw_siblings,
         }
@@ -175,14 +173,13 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn get_width(&self) -> Option<Size> {
-        self.extra
-            .container_width
+        self.container_width
             .as_ref()
             .map(|w| Size::Pixel(w.clone()))
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn set_siblings(&mut self, value: usize) {

--- a/packages/mrml-core/src/mj_social/render.rs
+++ b/packages/mrml-core/src/mj_social/render.rs
@@ -5,11 +5,10 @@ use super::{MjSocial, MjSocialChild, NAME};
 use crate::helper::condition::conditional_tag;
 use crate::helper::size::{Pixel, Size};
 use crate::helper::tag::Tag;
-use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSocialChild {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         match self {
             Self::MjSocialElement(elt) => elt.renderer(header),
             Self::Comment(elt) => elt.renderer(header),
@@ -124,7 +123,7 @@ impl<'e, 'h> MjSocialRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjSocialRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjSocialRender<'e, 'h> {
     fn default_attribute(&self, name: &str) -> Option<&str> {
         match name {
             "align" => Some("center"),
@@ -141,8 +140,8 @@ impl<'e, 'h> Render<'h> for MjSocialRender<'e, 'h> {
         }
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -183,7 +182,7 @@ impl<'e, 'h> Render<'h> for MjSocialRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSocial {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjSocialRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_social_element/network.rs
+++ b/packages/mrml-core/src/mj_social_element/network.rs
@@ -1,12 +1,12 @@
 pub struct SocialNetwork {
-    background_color: String,
-    share_url: Option<String>,
-    icon: String,
+    background_color: &'static str,
+    share_url: Option<&'static str>,
+    icon: &'static str,
 }
 
 impl SocialNetwork {
     pub fn background_color(&self) -> &str {
-        &self.background_color
+        self.background_color
     }
 
     pub fn share_url(&self, url: &str) -> Option<String> {
@@ -53,160 +53,157 @@ impl SocialNetwork {
 
     fn dribbble() -> Self {
         Self {
-            background_color: "#D95988".to_string(),
+            background_color: "#D95988",
             share_url: None,
-            icon: "dribbble.png".to_string(),
+            icon: "dribbble.png",
         }
     }
 
     fn facebook(noshare: bool) -> Self {
         Self {
-            background_color: "#3b5998".to_string(),
+            background_color: "#3b5998",
             share_url: if noshare {
                 None
             } else {
-                Some("https://www.facebook.com/sharer/sharer.php?u=[[URL]]".to_string())
+                Some("https://www.facebook.com/sharer/sharer.php?u=[[URL]]")
             },
-            icon: "facebook.png".to_string(),
+            icon: "facebook.png",
         }
     }
 
     fn github() -> Self {
         Self {
-            background_color: "#000000".to_string(),
+            background_color: "#000000",
             share_url: None,
-            icon: "github.png".to_string(),
+            icon: "github.png",
         }
     }
 
     fn google(noshare: bool) -> Self {
         Self {
-            background_color: "#dc4e41".to_string(),
+            background_color: "#dc4e41",
             share_url: if noshare {
                 None
             } else {
-                Some("https://plus.google.com/share?url=[[URL]]".to_string())
+                Some("https://plus.google.com/share?url=[[URL]]")
             },
-            icon: "google-plus.png".to_string(),
+            icon: "google-plus.png",
         }
     }
 
     fn instagram() -> Self {
         Self {
-            background_color: "#3f729b".to_string(),
+            background_color: "#3f729b",
             share_url: None,
-            icon: "instagram.png".to_string(),
+            icon: "instagram.png",
         }
     }
 
     fn linkedin(noshare: bool) -> Self {
         Self {
-            background_color: "#0077b5".to_string(),
+            background_color: "#0077b5",
             share_url: if noshare {
                 None
             } else {
-                Some("https://www.linkedin.com/shareArticle?mini=true&url=[[URL]]&title=&summary=&source=".to_string())
+                Some("https://www.linkedin.com/shareArticle?mini=true&url=[[URL]]&title=&summary=&source=")
             },
-            icon: "linkedin.png".to_string(),
+            icon: "linkedin.png",
         }
     }
 
     fn medium() -> Self {
         Self {
-            background_color: "#000000".to_string(),
+            background_color: "#000000",
             share_url: None,
-            icon: "medium.png".to_string(),
+            icon: "medium.png",
         }
     }
 
     fn pinterest(noshare: bool) -> Self {
         Self {
-            background_color: "#bd081c".to_string(),
+            background_color: "#bd081c",
             share_url: if noshare {
                 None
             } else {
-                Some(
-                    "https://pinterest.com/pin/create/button/?url=[[URL]]&media=&description="
-                        .to_string(),
-                )
+                Some("https://pinterest.com/pin/create/button/?url=[[URL]]&media=&description=")
             },
-            icon: "pinterest.png".to_string(),
+            icon: "pinterest.png",
         }
     }
 
     fn snapchat() -> Self {
         Self {
-            background_color: "#FFFA54".to_string(),
+            background_color: "#FFFA54",
             share_url: None,
-            icon: "snapchat.png".to_string(),
+            icon: "snapchat.png",
         }
     }
 
     fn soundcloud() -> Self {
         Self {
-            background_color: "#EF7F31".to_string(),
+            background_color: "#EF7F31",
             share_url: None,
-            icon: "soundcloud.png".to_string(),
+            icon: "soundcloud.png",
         }
     }
 
     fn tumblr(noshare: bool) -> Self {
         Self {
-            background_color: "#344356".to_string(),
+            background_color: "#344356",
             share_url: if noshare {
                 None
             } else {
-                Some("https://www.tumblr.com/widgets/share/tool?canonicalUrl=[[URL]]".to_string())
+                Some("https://www.tumblr.com/widgets/share/tool?canonicalUrl=[[URL]]")
             },
-            icon: "tumblr.png".to_string(),
+            icon: "tumblr.png",
         }
     }
 
     fn twitter(noshare: bool) -> Self {
         Self {
-            background_color: "#55acee".to_string(),
+            background_color: "#55acee",
             share_url: if noshare {
                 None
             } else {
-                Some("https://twitter.com/home?status=[[URL]]".to_string())
+                Some("https://twitter.com/home?status=[[URL]]")
             },
-            icon: "twitter.png".to_string(),
+            icon: "twitter.png",
         }
     }
 
     fn vimeo() -> Self {
         Self {
-            background_color: "#53B4E7".to_string(),
+            background_color: "#53B4E7",
             share_url: None,
-            icon: "vimeo.png".to_string(),
+            icon: "vimeo.png",
         }
     }
 
     fn web() -> Self {
         Self {
-            background_color: "#4BADE9".to_string(),
+            background_color: "#4BADE9",
             share_url: None,
-            icon: "web.png".to_string(),
+            icon: "web.png",
         }
     }
 
     fn xing(noshare: bool) -> Self {
         Self {
-            background_color: "#296366".to_string(),
+            background_color: "#296366",
             share_url: if noshare {
                 None
             } else {
-                Some("https://www.xing.com/app/user?op=share&url=[[URL]]".to_string())
+                Some("https://www.xing.com/app/user?op=share&url=[[URL]]")
             },
-            icon: "xing.png".to_string(),
+            icon: "xing.png",
         }
     }
 
     fn youtube() -> Self {
         Self {
-            background_color: "#EB3323".to_string(),
+            background_color: "#EB3323",
             share_url: None,
-            icon: "youtube.png".to_string(),
+            icon: "youtube.png",
         }
     }
 }

--- a/packages/mrml-core/src/mj_social_element/render.rs
+++ b/packages/mrml-core/src/mj_social_element/render.rs
@@ -162,7 +162,7 @@ impl<'e, 'h> MjSocialElementRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjSocialElementRender<'e, 'h> {
-    fn default_attribute(&self, key: &str) -> Option<&str> {
+    fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("left"),
             "color" => Some("#000"),

--- a/packages/mrml-core/src/mj_social_element/render.rs
+++ b/packages/mrml-core/src/mj_social_element/render.rs
@@ -102,7 +102,7 @@ impl<'e, 'h> MjSocialElementRender<'e, 'h> {
             .unwrap_or_default()
     }
 
-    fn render_icon(&self, href: &Option<String>, buf: &mut RenderBuffer) {
+    fn render_icon(&self, href: &Option<String>, cursor: &mut RenderCursor) {
         let table = self.set_style_table(Tag::table_presentation());
         let tbody = Tag::tbody();
         let tr = Tag::tr();
@@ -127,29 +127,24 @@ impl<'e, 'h> MjSocialElementRender<'e, 'h> {
                 self.get_icon_size().map(|size| size.value().to_string()),
             );
 
-        table.render_open(buf);
-        tbody.render_open(buf);
-        tr.render_open(buf);
-        td.render_open(buf);
+        table.render_open(&mut cursor.buffer);
+        tbody.render_open(&mut cursor.buffer);
+        tr.render_open(&mut cursor.buffer);
+        td.render_open(&mut cursor.buffer);
         if href.is_some() {
-            a.render_open(buf);
-            img.render_closed(buf);
-            a.render_close(buf);
+            a.render_open(&mut cursor.buffer);
+            img.render_closed(&mut cursor.buffer);
+            a.render_close(&mut cursor.buffer);
         } else {
-            img.render_closed(buf);
+            img.render_closed(&mut cursor.buffer);
         }
-        td.render_close(buf);
-        tr.render_close(buf);
-        tbody.render_close(buf);
-        table.render_close(buf);
+        td.render_close(&mut cursor.buffer);
+        tr.render_close(&mut cursor.buffer);
+        tbody.render_close(&mut cursor.buffer);
+        table.render_close(&mut cursor.buffer);
     }
 
-    fn render_text(
-        &self,
-        href: &Option<String>,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_text(&self, href: &Option<String>, cursor: &mut RenderCursor) -> Result<(), Error> {
         let td = self.set_style_td_text(Tag::td());
         let wrapper = if href.is_some() {
             Tag::new("a")
@@ -161,14 +156,14 @@ impl<'e, 'h> MjSocialElementRender<'e, 'h> {
         };
         let wrapper = self.set_style_text(wrapper);
 
-        td.render_open(buf);
-        wrapper.render_open(buf);
+        td.render_open(&mut cursor.buffer);
+        wrapper.render_open(&mut cursor.buffer);
         for child in self.element.children.iter() {
             let renderer = child.renderer(self.context());
-            renderer.render(header, buf)?;
+            renderer.render(cursor)?;
         }
-        wrapper.render_close(buf);
-        td.render_close(buf);
+        wrapper.render_close(&mut cursor.buffer);
+        td.render_close(&mut cursor.buffer);
         Ok(())
     }
 }
@@ -215,19 +210,19 @@ impl<'e, 'h> Render<'e, 'h> for MjSocialElementRender<'e, 'h> {
         self.context
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let href = self.get_href();
         let tr = Tag::tr().maybe_add_class(self.attribute("css-class"));
         let td = self.set_style_td(Tag::td());
 
-        tr.render_open(buf);
-        td.render_open(buf);
-        self.render_icon(&href, buf);
-        td.render_close(buf);
+        tr.render_open(&mut cursor.buffer);
+        td.render_open(&mut cursor.buffer);
+        self.render_icon(&href, cursor);
+        td.render_close(&mut cursor.buffer);
         if !self.element.children.is_empty() {
-            self.render_text(&href, header, buf)?;
+            self.render_text(&href, cursor)?;
         }
-        tr.render_close(buf);
+        tr.render_close(&mut cursor.buffer);
         Ok(())
     }
 }

--- a/packages/mrml-core/src/mj_social_element/render.rs
+++ b/packages/mrml-core/src/mj_social_element/render.rs
@@ -9,12 +9,12 @@ use crate::prelude::render::*;
 const DEFAULT_ICON_ORIGIN: &str = "https://www.mailjet.com/images/theme/v1/icons/ico-social/";
 
 #[derive(Default)]
-struct MjSocialElementExtra {
-    attributes: Map<String, String>,
+struct MjSocialElementExtra<'a> {
+    attributes: Map<&'a str, &'a str>,
     network: Option<SocialNetwork>,
 }
 
-impl MjSocialElementExtra {
+impl<'a> MjSocialElementExtra<'a> {
     pub fn new(network: Option<SocialNetwork>) -> Self {
         Self {
             attributes: Map::new(),
@@ -23,7 +23,7 @@ impl MjSocialElementExtra {
     }
 }
 
-impl<'root> Renderer<'root, MjSocialElement, MjSocialElementExtra> {
+impl<'root> Renderer<'root, MjSocialElement, MjSocialElementExtra<'root>> {
     fn get_background_color(&'root self) -> Option<&'root str> {
         if let Some(value) = self.attribute("background-color") {
             Some(value)
@@ -217,7 +217,7 @@ impl<'root> Renderer<'root, MjSocialElement, MjSocialElementExtra> {
     }
 }
 
-impl<'root> Render<'root> for Renderer<'root, MjSocialElement, MjSocialElementExtra> {
+impl<'root> Render<'root> for Renderer<'root, MjSocialElement, MjSocialElementExtra<'root>> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("left"),
@@ -235,14 +235,12 @@ impl<'root> Render<'root> for Renderer<'root, MjSocialElement, MjSocialElementEx
         }
     }
 
-    fn add_extra_attribute(&mut self, key: &str, value: &str) {
-        self.extra
-            .attributes
-            .insert(key.to_string(), value.to_string());
+    fn add_extra_attribute(&mut self, key: &'root str, value: &'root str) {
+        self.extra.attributes.insert(key, value);
     }
 
-    fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
-        self.extra.attributes.get(key).map(|v| v.as_str())
+    fn raw_extra_attribute(&self, key: &str) -> Option<&'root str> {
+        self.extra.attributes.get(key).copied()
     }
 
     fn raw_attribute(&self, key: &str) -> Option<&'root str> {

--- a/packages/mrml-core/src/mj_social_element/render.rs
+++ b/packages/mrml-core/src/mj_social_element/render.rs
@@ -9,7 +9,6 @@ const DEFAULT_ICON_ORIGIN: &str = "https://www.mailjet.com/images/theme/v1/icons
 #[derive(Default)]
 struct MjSocialElementExtra {
     attributes: Map<String, String>,
-    container_width: Option<Pixel>,
     network: Option<SocialNetwork>,
 }
 
@@ -17,7 +16,6 @@ impl MjSocialElementExtra {
     pub fn new(network: Option<SocialNetwork>) -> Self {
         Self {
             attributes: Map::new(),
-            container_width: None,
             network,
         }
     }
@@ -218,7 +216,7 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn context(&self) -> &'header RenderContext<'header> {

--- a/packages/mrml-core/src/mj_social_element/render.rs
+++ b/packages/mrml-core/src/mj_social_element/render.rs
@@ -4,9 +4,8 @@ use std::rc::Rc;
 use super::network::SocialNetwork;
 use super::{MjSocialElement, NAME};
 use crate::helper::size::{Pixel, Size};
-use crate::helper::tag::Tag;
 use crate::prelude::hash::Map;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 const DEFAULT_ICON_ORIGIN: &str = "https://www.mailjet.com/images/theme/v1/icons/ico-social/";
 

--- a/packages/mrml-core/src/mj_social_element/render.rs
+++ b/packages/mrml-core/src/mj_social_element/render.rs
@@ -46,12 +46,12 @@ impl<'e, 'h> MjSocialElementRender<'e, 'h> {
         })
     }
 
-    fn set_style_img(&self, tag: Tag) -> Tag {
+    fn set_style_img<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("border-radius", self.attribute("border-radius"))
             .add_style("display", "block")
     }
 
-    fn set_style_icon(&self, tag: Tag) -> Tag {
+    fn set_style_icon<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("padding", self.attribute("icon-padding"))
             .add_style("font-size", "0")
             .maybe_add_style(
@@ -64,13 +64,13 @@ impl<'e, 'h> MjSocialElementRender<'e, 'h> {
             .maybe_add_style("width", self.get_icon_size().map(|item| item.to_string()))
     }
 
-    fn set_style_table(&self, tag: Tag) -> Tag {
+    fn set_style_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("background", self.get_background_color())
             .maybe_add_style("border-radius", self.attribute("border-radius"))
             .maybe_add_style("width", self.get_icon_size().map(|size| size.to_string()))
     }
 
-    fn set_style_td(&self, tag: Tag) -> Tag {
+    fn set_style_td<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("padding", self.attribute("padding"))
             .maybe_add_style("padding-top", self.attribute("padding-top"))
             .maybe_add_style("padding-right", self.attribute("padding-right"))
@@ -79,12 +79,12 @@ impl<'e, 'h> MjSocialElementRender<'e, 'h> {
             .maybe_add_style("vertical-align", self.attribute("vertical-align"))
     }
 
-    fn set_style_td_text(&self, tag: Tag) -> Tag {
+    fn set_style_td_text<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.add_style("vertical-align", "middle")
             .maybe_add_style("padding", self.attribute("text-padding"))
     }
 
-    fn set_style_text(&self, tag: Tag) -> Tag {
+    fn set_style_text<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("color", self.attribute("color"))
             .maybe_add_style("font-size", self.attribute("font-size"))
             .maybe_add_style("font-weight", self.attribute("font-weight"))

--- a/packages/mrml-core/src/mj_social_element/render.rs
+++ b/packages/mrml-core/src/mj_social_element/render.rs
@@ -21,7 +21,7 @@ impl MjSocialElementExtra {
     }
 }
 
-impl<'element, 'header> Renderer<'element, 'header, MjSocialElement, MjSocialElementExtra> {
+impl<'root> Renderer<'root, MjSocialElement, MjSocialElementExtra> {
     fn get_background_color(&self) -> Option<String> {
         self.attribute("background-color").or_else(|| {
             self.extra
@@ -177,9 +177,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjSocialElement, MjSocialEle
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjSocialElement, MjSocialElementExtra>
-{
+impl<'root> Render<'root> for Renderer<'root, MjSocialElement, MjSocialElementExtra> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("left"),
@@ -207,7 +205,7 @@ impl<'element, 'header> Render<'element, 'header>
         self.extra.attributes.get(key).map(|v| v.as_str())
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -219,7 +217,7 @@ impl<'element, 'header> Render<'element, 'header>
         self.container_width = width;
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -240,8 +238,11 @@ impl<'element, 'header> Render<'element, 'header>
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSocialElement {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjSocialElement {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         let extra = MjSocialElementExtra::new(
             self.attributes
                 .get("name")

--- a/packages/mrml-core/src/mj_social_element/render.rs
+++ b/packages/mrml-core/src/mj_social_element/render.rs
@@ -161,7 +161,7 @@ impl<'e, 'h> MjSocialElementRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjSocialElementRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjSocialElementRender<'e, 'h> {
     fn default_attribute(&self, key: &str) -> Option<&str> {
         match key {
             "align" => Some("left"),
@@ -183,12 +183,12 @@ impl<'e, 'h> Render<'h> for MjSocialElementRender<'e, 'h> {
         self.extra.insert(key.to_string(), value.to_string());
     }
 
-    fn extra_attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.extra)
+    fn raw_extra_attribute(&self, key: &str) -> Option<&str> {
+        self.extra.get(key).map(|v| v.as_str())
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -217,7 +217,7 @@ impl<'e, 'h> Render<'h> for MjSocialElementRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSocialElement {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjSocialElementRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_spacer/render.rs
+++ b/packages/mrml-core/src/mj_spacer/render.rs
@@ -2,7 +2,7 @@ use super::{MjSpacer, NAME};
 use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjSpacer, ()> {
+impl<'root> Render<'root> for Renderer<'root, MjSpacer, ()> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "height" => Some("20px"),
@@ -10,7 +10,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -22,7 +22,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         self.container_width = width;
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -35,8 +35,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSpacer {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjSpacer {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/mj_spacer/render.rs
+++ b/packages/mrml-core/src/mj_spacer/render.rs
@@ -3,8 +3,7 @@ use std::rc::Rc;
 
 use super::{MjSpacer, NAME};
 use crate::helper::size::Pixel;
-use crate::helper::tag::Tag;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 struct MjSpacerRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,

--- a/packages/mrml-core/src/mj_spacer/render.rs
+++ b/packages/mrml-core/src/mj_spacer/render.rs
@@ -32,11 +32,11 @@ impl<'e, 'h> Render<'e, 'h> for MjSpacerRender<'e, 'h> {
         self.context
     }
 
-    fn render(&self, _header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         Tag::div()
             .maybe_add_style("height", self.attribute("height"))
             .maybe_add_style("line-height", self.attribute("height"))
-            .render_text(buf, "&#8202;");
+            .render_text(&mut cursor.buffer, "&#8202;");
         Ok(())
     }
 }

--- a/packages/mrml-core/src/mj_spacer/render.rs
+++ b/packages/mrml-core/src/mj_spacer/render.rs
@@ -2,13 +2,14 @@ use super::{MjSpacer, NAME};
 use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
-struct MjSpacerRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e MjSpacer,
+#[derive(Default)]
+struct MjSpacerExtra {
     container_width: Option<Pixel>,
 }
 
-impl<'e, 'h> Render<'e, 'h> for MjSpacerRender<'e, 'h> {
+impl<'element, 'header> Render<'element, 'header>
+    for Renderer<'element, 'header, MjSpacer, MjSpacerExtra>
+{
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "height" => Some("20px"),
@@ -16,7 +17,7 @@ impl<'e, 'h> Render<'e, 'h> for MjSpacerRender<'e, 'h> {
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -25,10 +26,10 @@ impl<'e, 'h> Render<'e, 'h> for MjSpacerRender<'e, 'h> {
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.container_width = width;
+        self.extra.container_width = width;
     }
 
-    fn context(&self) -> &'h RenderContext<'h> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
@@ -43,11 +44,7 @@ impl<'e, 'h> Render<'e, 'h> for MjSpacerRender<'e, 'h> {
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSpacer {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjSpacerRender::<'e, 'h> {
-            element: self,
-            context,
-            container_width: None,
-        })
+        Box::new(Renderer::new(context, self, MjSpacerExtra::default()))
     }
 }
 

--- a/packages/mrml-core/src/mj_spacer/render.rs
+++ b/packages/mrml-core/src/mj_spacer/render.rs
@@ -4,7 +4,6 @@ use std::rc::Rc;
 use super::{MjSpacer, NAME};
 use crate::helper::size::Pixel;
 use crate::helper::tag::Tag;
-use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 struct MjSpacerRender<'e, 'h> {
@@ -13,7 +12,7 @@ struct MjSpacerRender<'e, 'h> {
     container_width: Option<Pixel>,
 }
 
-impl<'e, 'h> Render<'h> for MjSpacerRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjSpacerRender<'e, 'h> {
     fn default_attribute(&self, key: &str) -> Option<&str> {
         match key {
             "height" => Some("20px"),
@@ -21,8 +20,8 @@ impl<'e, 'h> Render<'h> for MjSpacerRender<'e, 'h> {
         }
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -46,7 +45,7 @@ impl<'e, 'h> Render<'h> for MjSpacerRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSpacer {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjSpacerRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_spacer/render.rs
+++ b/packages/mrml-core/src/mj_spacer/render.rs
@@ -3,7 +3,7 @@ use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
 struct MjSpacerRender<'e, 'h> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e MjSpacer,
     container_width: Option<Pixel>,
 }
@@ -28,16 +28,11 @@ impl<'e, 'h> Render<'e, 'h> for MjSpacerRender<'e, 'h> {
         self.container_width = width;
     }
 
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        self.context
     }
 
-    fn render(
-        &self,
-        _opts: &RenderOptions,
-        _header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render(&self, _header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
         Tag::div()
             .maybe_add_style("height", self.attribute("height"))
             .maybe_add_style("line-height", self.attribute("height"))
@@ -47,10 +42,10 @@ impl<'e, 'h> Render<'e, 'h> for MjSpacerRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSpacer {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjSpacerRender::<'e, 'h> {
             element: self,
-            header,
+            context,
             container_width: None,
         })
     }

--- a/packages/mrml-core/src/mj_spacer/render.rs
+++ b/packages/mrml-core/src/mj_spacer/render.rs
@@ -1,12 +1,9 @@
-use std::cell::{Ref, RefCell};
-use std::rc::Rc;
-
 use super::{MjSpacer, NAME};
 use crate::helper::size::Pixel;
-use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
+use crate::prelude::render::*;
 
 struct MjSpacerRender<'e, 'h> {
-    header: Rc<RefCell<Header<'h>>>,
+    header: &'h Header<'h>,
     element: &'e MjSpacer,
     container_width: Option<Pixel>,
 }
@@ -31,11 +28,16 @@ impl<'e, 'h> Render<'e, 'h> for MjSpacerRender<'e, 'h> {
         self.container_width = width;
     }
 
-    fn header(&self) -> Ref<Header<'h>> {
-        self.header.borrow()
+    fn header(&self) -> &'h Header<'h> {
+        self.header
     }
 
-    fn render(&self, _opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(
+        &self,
+        _opts: &RenderOptions,
+        _header: &mut VariableHeader,
+        buf: &mut RenderBuffer,
+    ) -> Result<(), Error> {
         Tag::div()
             .maybe_add_style("height", self.attribute("height"))
             .maybe_add_style("line-height", self.attribute("height"))
@@ -45,7 +47,7 @@ impl<'e, 'h> Render<'e, 'h> for MjSpacerRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSpacer {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjSpacerRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_spacer/render.rs
+++ b/packages/mrml-core/src/mj_spacer/render.rs
@@ -13,7 +13,7 @@ struct MjSpacerRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjSpacerRender<'e, 'h> {
-    fn default_attribute(&self, key: &str) -> Option<&str> {
+    fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "height" => Some("20px"),
             _ => None,

--- a/packages/mrml-core/src/mj_spacer/render.rs
+++ b/packages/mrml-core/src/mj_spacer/render.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use super::{MjSpacer, NAME};
 use crate::helper::size::Pixel;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
+use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
 
 struct MjSpacerRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,
@@ -35,11 +35,12 @@ impl<'e, 'h> Render<'e, 'h> for MjSpacerRender<'e, 'h> {
         self.header.borrow()
     }
 
-    fn render(&self, _opts: &RenderOptions) -> Result<String, Error> {
-        Ok(Tag::div()
+    fn render(&self, _opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
+        Tag::div()
             .maybe_add_style("height", self.attribute("height"))
             .maybe_add_style("line-height", self.attribute("height"))
-            .render("&#8202;"))
+            .render_text(buf, "&#8202;");
+        Ok(())
     }
 }
 

--- a/packages/mrml-core/src/mj_spacer/render.rs
+++ b/packages/mrml-core/src/mj_spacer/render.rs
@@ -2,14 +2,7 @@ use super::{MjSpacer, NAME};
 use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
-#[derive(Default)]
-struct MjSpacerExtra {
-    container_width: Option<Pixel>,
-}
-
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjSpacer, MjSpacerExtra>
-{
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjSpacer, ()> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "height" => Some("20px"),
@@ -26,7 +19,7 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn context(&self) -> &'header RenderContext<'header> {
@@ -44,7 +37,7 @@ impl<'element, 'header> Render<'element, 'header>
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjSpacer {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(Renderer::new(context, self, MjSpacerExtra::default()))
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_table/render.rs
+++ b/packages/mrml-core/src/mj_table/render.rs
@@ -28,7 +28,7 @@ impl<'e, 'h> MjTableRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjTableRender<'e, 'h> {
-    fn default_attribute(&self, name: &str) -> Option<&str> {
+    fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "align" => Some("left"),
             "border" => Some("none"),

--- a/packages/mrml-core/src/mj_table/render.rs
+++ b/packages/mrml-core/src/mj_table/render.rs
@@ -3,9 +3,8 @@ use std::rc::Rc;
 
 use super::{MjTable, NAME};
 use crate::helper::size::Pixel;
-use crate::helper::tag::Tag;
 use crate::mj_section::WithMjSectionBackground;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 struct MjTableRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,

--- a/packages/mrml-core/src/mj_table/render.rs
+++ b/packages/mrml-core/src/mj_table/render.rs
@@ -50,16 +50,16 @@ impl<'e, 'h> Render<'e, 'h> for MjTableRender<'e, 'h> {
     }
 
     fn context(&self) -> &'h RenderContext<'h> {
-        &self.context
+        self.context
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
         self.container_width = width;
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let font_family = self.attribute("font-family");
-        header.maybe_add_font_families(font_family);
+        cursor.header.maybe_add_font_families(font_family);
 
         let table = self
             .set_style_table(Tag::table())
@@ -67,13 +67,13 @@ impl<'e, 'h> Render<'e, 'h> for MjTableRender<'e, 'h> {
             .maybe_add_attribute("cellpadding", self.attribute("cellpadding"))
             .maybe_add_attribute("cellspacing", self.attribute("cellspacing"))
             .maybe_add_attribute("width", self.attribute("width"));
-        table.render_open(buf);
+        table.render_open(&mut cursor.buffer);
         for (index, child) in self.element.children.iter().enumerate() {
             let mut renderer = child.renderer(self.context());
             renderer.set_index(index);
-            renderer.render(header, buf)?;
+            renderer.render(cursor)?;
         }
-        table.render_close(buf);
+        table.render_close(&mut cursor.buffer);
         Ok(())
     }
 }

--- a/packages/mrml-core/src/mj_table/render.rs
+++ b/packages/mrml-core/src/mj_table/render.rs
@@ -4,7 +4,7 @@ use crate::mj_section::WithMjSectionBackground;
 use crate::prelude::render::*;
 
 struct MjTableRender<'e, 'h> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e MjTable,
     container_width: Option<Pixel>,
 }
@@ -49,20 +49,15 @@ impl<'e, 'h> Render<'e, 'h> for MjTableRender<'e, 'h> {
         Some(NAME)
     }
 
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        &self.context
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
         self.container_width = width;
     }
 
-    fn render(
-        &self,
-        opts: &RenderOptions,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
         let font_family = self.attribute("font-family");
         header.maybe_add_font_families(font_family);
 
@@ -74,9 +69,9 @@ impl<'e, 'h> Render<'e, 'h> for MjTableRender<'e, 'h> {
             .maybe_add_attribute("width", self.attribute("width"));
         table.render_open(buf);
         for (index, child) in self.element.children.iter().enumerate() {
-            let mut renderer = child.renderer(self.header);
+            let mut renderer = child.renderer(self.context());
             renderer.set_index(index);
-            renderer.render(opts, header, buf)?;
+            renderer.render(header, buf)?;
         }
         table.render_close(buf);
         Ok(())
@@ -84,10 +79,10 @@ impl<'e, 'h> Render<'e, 'h> for MjTableRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjTable {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjTableRender::<'e, 'h> {
             element: self,
-            header,
+            context,
             container_width: None,
         })
     }

--- a/packages/mrml-core/src/mj_table/render.rs
+++ b/packages/mrml-core/src/mj_table/render.rs
@@ -15,7 +15,7 @@ struct MjTableRender<'e, 'h> {
 impl<'e, 'h> WithMjSectionBackground<'e, 'h> for MjTableRender<'e, 'h> {}
 
 impl<'e, 'h> MjTableRender<'e, 'h> {
-    fn set_style_table(&self, tag: Tag) -> Tag {
+    fn set_style_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("color", self.attribute("color"))
             .maybe_add_style("font-family", self.attribute("font-family"))
             .maybe_add_style("font-size", self.attribute("font-size"))

--- a/packages/mrml-core/src/mj_table/render.rs
+++ b/packages/mrml-core/src/mj_table/render.rs
@@ -5,7 +5,6 @@ use super::{MjTable, NAME};
 use crate::helper::size::Pixel;
 use crate::helper::tag::Tag;
 use crate::mj_section::WithMjSectionBackground;
-use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 struct MjTableRender<'e, 'h> {
@@ -14,7 +13,7 @@ struct MjTableRender<'e, 'h> {
     container_width: Option<Pixel>,
 }
 
-impl<'e, 'h> WithMjSectionBackground<'h> for MjTableRender<'e, 'h> {}
+impl<'e, 'h> WithMjSectionBackground<'e, 'h> for MjTableRender<'e, 'h> {}
 
 impl<'e, 'h> MjTableRender<'e, 'h> {
     fn set_style_table(&self, tag: Tag) -> Tag {
@@ -28,7 +27,7 @@ impl<'e, 'h> MjTableRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjTableRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjTableRender<'e, 'h> {
     fn default_attribute(&self, name: &str) -> Option<&str> {
         match name {
             "align" => Some("left"),
@@ -46,8 +45,8 @@ impl<'e, 'h> Render<'h> for MjTableRender<'e, 'h> {
         }
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -86,7 +85,7 @@ impl<'e, 'h> Render<'h> for MjTableRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjTable {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjTableRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_table/render.rs
+++ b/packages/mrml-core/src/mj_table/render.rs
@@ -3,12 +3,9 @@ use crate::helper::size::Pixel;
 use crate::mj_section::WithMjSectionBackground;
 use crate::prelude::render::*;
 
-impl<'element, 'header> WithMjSectionBackground<'element, 'header>
-    for Renderer<'element, 'header, MjTable, ()>
-{
-}
+impl<'root> WithMjSectionBackground<'root> for Renderer<'root, MjTable, ()> {}
 
-impl<'element, 'header> Renderer<'element, 'header, MjTable, ()> {
+impl<'root> Renderer<'root, MjTable, ()> {
     fn set_style_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("color", self.attribute("color"))
             .maybe_add_style("font-family", self.attribute("font-family"))
@@ -20,7 +17,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjTable, ()> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjTable, ()> {
+impl<'root> Render<'root> for Renderer<'root, MjTable, ()> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "align" => Some("left"),
@@ -38,7 +35,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -46,7 +43,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         Some(NAME)
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -75,11 +72,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjTable {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjTable {
     fn renderer(
-        &'element self,
-        context: &'header RenderContext<'header>,
-    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/mj_table/render.rs
+++ b/packages/mrml-core/src/mj_table/render.rs
@@ -3,15 +3,17 @@ use crate::helper::size::Pixel;
 use crate::mj_section::WithMjSectionBackground;
 use crate::prelude::render::*;
 
-struct MjTableRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e MjTable,
+#[derive(Default)]
+struct MjTableExtra {
     container_width: Option<Pixel>,
 }
 
-impl<'e, 'h> WithMjSectionBackground<'e, 'h> for MjTableRender<'e, 'h> {}
+impl<'element, 'header> WithMjSectionBackground<'element, 'header>
+    for Renderer<'element, 'header, MjTable, MjTableExtra>
+{
+}
 
-impl<'e, 'h> MjTableRender<'e, 'h> {
+impl<'element, 'header> Renderer<'element, 'header, MjTable, MjTableExtra> {
     fn set_style_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("color", self.attribute("color"))
             .maybe_add_style("font-family", self.attribute("font-family"))
@@ -23,7 +25,9 @@ impl<'e, 'h> MjTableRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'e, 'h> for MjTableRender<'e, 'h> {
+impl<'element, 'header> Render<'element, 'header>
+    for Renderer<'element, 'header, MjTable, MjTableExtra>
+{
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "align" => Some("left"),
@@ -41,7 +45,7 @@ impl<'e, 'h> Render<'e, 'h> for MjTableRender<'e, 'h> {
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -49,12 +53,12 @@ impl<'e, 'h> Render<'e, 'h> for MjTableRender<'e, 'h> {
         Some(NAME)
     }
 
-    fn context(&self) -> &'h RenderContext<'h> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.container_width = width;
+        self.extra.container_width = width;
     }
 
     fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
@@ -78,13 +82,12 @@ impl<'e, 'h> Render<'e, 'h> for MjTableRender<'e, 'h> {
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjTable {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjTableRender::<'e, 'h> {
-            element: self,
-            context,
-            container_width: None,
-        })
+impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjTable {
+    fn renderer(
+        &'element self,
+        context: &'header RenderContext<'header>,
+    ) -> Box<dyn Render<'element, 'header> + 'r> {
+        Box::new(Renderer::new(context, self, MjTableExtra::default()))
     }
 }
 

--- a/packages/mrml-core/src/mj_table/render.rs
+++ b/packages/mrml-core/src/mj_table/render.rs
@@ -6,7 +6,11 @@ use crate::prelude::render::*;
 impl<'root> WithMjSectionBackground<'root> for Renderer<'root, MjTable, ()> {}
 
 impl<'root> Renderer<'root, MjTable, ()> {
-    fn set_style_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_table<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.maybe_add_style("color", self.attribute("color"))
             .maybe_add_style("font-family", self.attribute("font-family"))
             .maybe_add_style("font-size", self.attribute("font-size"))

--- a/packages/mrml-core/src/mj_table/render.rs
+++ b/packages/mrml-core/src/mj_table/render.rs
@@ -3,17 +3,12 @@ use crate::helper::size::Pixel;
 use crate::mj_section::WithMjSectionBackground;
 use crate::prelude::render::*;
 
-#[derive(Default)]
-struct MjTableExtra {
-    container_width: Option<Pixel>,
-}
-
 impl<'element, 'header> WithMjSectionBackground<'element, 'header>
-    for Renderer<'element, 'header, MjTable, MjTableExtra>
+    for Renderer<'element, 'header, MjTable, ()>
 {
 }
 
-impl<'element, 'header> Renderer<'element, 'header, MjTable, MjTableExtra> {
+impl<'element, 'header> Renderer<'element, 'header, MjTable, ()> {
     fn set_style_table<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("color", self.attribute("color"))
             .maybe_add_style("font-family", self.attribute("font-family"))
@@ -25,9 +20,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjTable, MjTableExtra> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjTable, MjTableExtra>
-{
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjTable, ()> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "align" => Some("left"),
@@ -58,7 +51,7 @@ impl<'element, 'header> Render<'element, 'header>
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
+        self.container_width = width;
     }
 
     fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
@@ -87,7 +80,7 @@ impl<'r, 'element: 'r, 'header: 'r> Renderable<'r, 'element, 'header> for MjTabl
         &'element self,
         context: &'header RenderContext<'header>,
     ) -> Box<dyn Render<'element, 'header> + 'r> {
-        Box::new(Renderer::new(context, self, MjTableExtra::default()))
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_text/render.rs
+++ b/packages/mrml-core/src/mj_text/render.rs
@@ -2,7 +2,6 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::{MjText, NAME};
-use crate::helper::condition::{END_CONDITIONAL_TAG, START_CONDITIONAL_TAG};
 use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
 
 struct MjTextRender<'e, 'h> {
@@ -49,17 +48,17 @@ impl<'e, 'h> MjTextRender<'e, 'h> {
             .add_style("vertical-align", "top")
             .add_style("height", height.to_owned());
 
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         table.render_open(buf);
         tr.render_open(buf);
         td.render_open(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
         self.render_content(opts, buf)?;
-        buf.push_str(START_CONDITIONAL_TAG);
+        buf.start_conditional_tag();
         td.render_close(buf);
         tr.render_close(buf);
         table.render_close(buf);
-        buf.push_str(END_CONDITIONAL_TAG);
+        buf.end_conditional_tag();
         Ok(())
     }
 }

--- a/packages/mrml-core/src/mj_text/render.rs
+++ b/packages/mrml-core/src/mj_text/render.rs
@@ -1,7 +1,7 @@
 use super::{MjText, NAME};
 use crate::prelude::render::*;
 
-impl<'element, 'header> Renderer<'element, 'header, MjText, ()> {
+impl<'root> Renderer<'root, MjText, ()> {
     fn set_style_text<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("font-family", self.attribute("font-family"))
             .maybe_add_style("font-size", self.attribute("font-size"))
@@ -49,7 +49,7 @@ impl<'element, 'header> Renderer<'element, 'header, MjText, ()> {
     }
 }
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjText, ()> {
+impl<'root> Render<'root> for Renderer<'root, MjText, ()> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("left"),
@@ -62,7 +62,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -70,7 +70,7 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         Some(NAME)
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -86,8 +86,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjText {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjText {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/mj_text/render.rs
+++ b/packages/mrml-core/src/mj_text/render.rs
@@ -3,8 +3,7 @@ use std::rc::Rc;
 
 use super::{MjText, NAME};
 use crate::helper::condition::conditional_tag;
-use crate::helper::tag::Tag;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 struct MjTextRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,

--- a/packages/mrml-core/src/mj_text/render.rs
+++ b/packages/mrml-core/src/mj_text/render.rs
@@ -2,7 +2,11 @@ use super::{MjText, NAME};
 use crate::prelude::render::*;
 
 impl<'root> Renderer<'root, MjText, ()> {
-    fn set_style_text<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
+    fn set_style_text<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
+    where
+        'root: 'a,
+        'a: 't,
+    {
         tag.maybe_add_style("font-family", self.attribute("font-family"))
             .maybe_add_style("font-size", self.attribute("font-size"))
             .maybe_add_style("font-style", self.attribute("font-style"))
@@ -78,7 +82,7 @@ impl<'root> Render<'root> for Renderer<'root, MjText, ()> {
         let font_family = self.attribute("font-family");
         cursor.header.maybe_add_font_families(font_family);
 
-        if let Some(ref height) = self.attribute("height") {
+        if let Some(height) = self.attribute("height") {
             self.render_with_height(height, cursor)
         } else {
             self.render_content(cursor)

--- a/packages/mrml-core/src/mj_text/render.rs
+++ b/packages/mrml-core/src/mj_text/render.rs
@@ -10,7 +10,7 @@ struct MjTextRender<'e, 'h> {
 }
 
 impl<'e, 'h> MjTextRender<'e, 'h> {
-    fn set_style_text(&self, tag: Tag) -> Tag {
+    fn set_style_text<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("font-family", self.attribute("font-family"))
             .maybe_add_style("font-size", self.attribute("font-size"))
             .maybe_add_style("font-style", self.attribute("font-style"))

--- a/packages/mrml-core/src/mj_text/render.rs
+++ b/packages/mrml-core/src/mj_text/render.rs
@@ -21,26 +21,17 @@ impl<'e, 'h> MjTextRender<'e, 'h> {
             .maybe_add_style("height", self.attribute("height"))
     }
 
-    fn render_content(
-        &self,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_content(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let root = self.set_style_text(Tag::div());
-        root.render_open(buf);
+        root.render_open(&mut cursor.buffer);
         for child in self.element.children.iter() {
-            child.renderer(self.context()).render(header, buf)?;
+            child.renderer(self.context()).render(cursor)?;
         }
-        root.render_close(buf);
+        root.render_close(&mut cursor.buffer);
         Ok(())
     }
 
-    fn render_with_height(
-        &self,
-        height: &str,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_with_height(&self, height: &str, cursor: &mut RenderCursor) -> Result<(), Error> {
         let table = Tag::table_presentation();
         let tr = Tag::tr();
         let td = Tag::td()
@@ -48,17 +39,17 @@ impl<'e, 'h> MjTextRender<'e, 'h> {
             .add_style("vertical-align", "top")
             .add_style("height", height.to_owned());
 
-        buf.start_conditional_tag();
-        table.render_open(buf);
-        tr.render_open(buf);
-        td.render_open(buf);
-        buf.end_conditional_tag();
-        self.render_content(header, buf)?;
-        buf.start_conditional_tag();
-        td.render_close(buf);
-        tr.render_close(buf);
-        table.render_close(buf);
-        buf.end_conditional_tag();
+        cursor.buffer.start_conditional_tag();
+        table.render_open(&mut cursor.buffer);
+        tr.render_open(&mut cursor.buffer);
+        td.render_open(&mut cursor.buffer);
+        cursor.buffer.end_conditional_tag();
+        self.render_content(cursor)?;
+        cursor.buffer.start_conditional_tag();
+        td.render_close(&mut cursor.buffer);
+        tr.render_close(&mut cursor.buffer);
+        table.render_close(&mut cursor.buffer);
+        cursor.buffer.end_conditional_tag();
         Ok(())
     }
 }
@@ -85,17 +76,17 @@ impl<'e, 'h> Render<'e, 'h> for MjTextRender<'e, 'h> {
     }
 
     fn context(&self) -> &'h RenderContext<'h> {
-        &self.context
+        self.context
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let font_family = self.attribute("font-family");
-        header.maybe_add_font_families(font_family);
+        cursor.header.maybe_add_font_families(font_family);
 
         if let Some(ref height) = self.attribute("height") {
-            self.render_with_height(height, header, buf)
+            self.render_with_height(height, cursor)
         } else {
-            self.render_content(header, buf)
+            self.render_content(cursor)
         }
     }
 }

--- a/packages/mrml-core/src/mj_text/render.rs
+++ b/packages/mrml-core/src/mj_text/render.rs
@@ -52,7 +52,7 @@ impl<'e, 'h> MjTextRender<'e, 'h> {
 }
 
 impl<'e, 'h> Render<'e, 'h> for MjTextRender<'e, 'h> {
-    fn default_attribute(&self, key: &str) -> Option<&str> {
+    fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("left"),
             "color" => Some("#000000"),

--- a/packages/mrml-core/src/mj_text/render.rs
+++ b/packages/mrml-core/src/mj_text/render.rs
@@ -4,7 +4,6 @@ use std::rc::Rc;
 use super::{MjText, NAME};
 use crate::helper::condition::conditional_tag;
 use crate::helper::tag::Tag;
-use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 struct MjTextRender<'e, 'h> {
@@ -52,7 +51,7 @@ impl<'e, 'h> MjTextRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjTextRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjTextRender<'e, 'h> {
     fn default_attribute(&self, key: &str) -> Option<&str> {
         match key {
             "align" => Some("left"),
@@ -65,8 +64,8 @@ impl<'e, 'h> Render<'h> for MjTextRender<'e, 'h> {
         }
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -91,7 +90,7 @@ impl<'e, 'h> Render<'h> for MjTextRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjText {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjTextRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_text/render.rs
+++ b/packages/mrml-core/src/mj_text/render.rs
@@ -1,12 +1,7 @@
 use super::{MjText, NAME};
 use crate::prelude::render::*;
 
-struct MjTextRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e MjText,
-}
-
-impl<'e, 'h> MjTextRender<'e, 'h> {
+impl<'element, 'header> Renderer<'element, 'header, MjText, ()> {
     fn set_style_text<'a>(&self, tag: Tag<'a>) -> Tag<'a> {
         tag.maybe_add_style("font-family", self.attribute("font-family"))
             .maybe_add_style("font-size", self.attribute("font-size"))
@@ -54,7 +49,7 @@ impl<'e, 'h> MjTextRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'e, 'h> for MjTextRender<'e, 'h> {
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjText, ()> {
     fn default_attribute(&self, key: &str) -> Option<&'static str> {
         match key {
             "align" => Some("left"),
@@ -67,7 +62,7 @@ impl<'e, 'h> Render<'e, 'h> for MjTextRender<'e, 'h> {
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -75,7 +70,7 @@ impl<'e, 'h> Render<'e, 'h> for MjTextRender<'e, 'h> {
         Some(NAME)
     }
 
-    fn context(&self) -> &'h RenderContext<'h> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
@@ -93,10 +88,7 @@ impl<'e, 'h> Render<'e, 'h> for MjTextRender<'e, 'h> {
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjText {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjTextRender::<'e, 'h> {
-            element: self,
-            context,
-        })
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_wrapper/render.rs
+++ b/packages/mrml-core/src/mj_wrapper/render.rs
@@ -3,117 +3,7 @@ use crate::helper::size::Pixel;
 use crate::mj_section::{SectionLikeRender, WithMjSectionBackground};
 use crate::prelude::render::*;
 
-#[derive(Default)]
-struct MjWrapperExtra {
-    container_width: Option<Pixel>,
-}
-
-impl<'element, 'header> Renderer<'element, 'header, MjWrapper, MjWrapperExtra> {
-    fn current_width(&self) -> Option<Pixel> {
-        self.extra.container_width.as_ref().map(|width| {
-            let hborder = self.get_border_horizontal();
-            let hpadding = self.get_padding_horizontal();
-            Pixel::new(width.value() - hborder.value() - hpadding.value())
-        })
-    }
-}
-
-impl<'element, 'header> WithMjSectionBackground<'element, 'header>
-    for Renderer<'element, 'header, MjWrapper, MjWrapperExtra>
-{
-}
-
-impl<'element, 'header> SectionLikeRender<'element, 'header>
-    for Renderer<'element, 'header, MjWrapper, MjWrapperExtra>
-{
-    fn children(&self) -> &Vec<crate::mj_body::MjBodyChild> {
-        &self.element.children
-    }
-
-    fn container_width(&self) -> &Option<Pixel> {
-        &self.extra.container_width
-    }
-
-    fn render_wrapped_children(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
-        let tr = Tag::tr();
-        let siblings = self.get_siblings();
-        let raw_siblings = self.get_raw_siblings();
-        let current_width = self.current_width();
-        let container_width = self.extra.container_width.as_ref().map(|v| v.to_string());
-        for child in self.children().iter() {
-            let mut renderer = child.renderer(self.context());
-            renderer.set_siblings(siblings);
-            renderer.set_raw_siblings(raw_siblings);
-            renderer.set_container_width(current_width.clone());
-            if child.is_raw() {
-                renderer.render(cursor)?;
-            } else {
-                let td = renderer
-                    .set_style("td-outlook", Tag::td())
-                    .maybe_add_attribute("align", renderer.attribute("align"))
-                    .maybe_add_attribute("width", container_width.as_ref().cloned())
-                    .maybe_add_suffixed_class(renderer.attribute("css-class"), "outlook");
-                tr.render_open(&mut cursor.buffer);
-                td.render_open(&mut cursor.buffer);
-                cursor.buffer.end_conditional_tag();
-                renderer.render(cursor)?;
-                cursor.buffer.start_conditional_tag();
-                td.render_close(&mut cursor.buffer);
-                tr.render_close(&mut cursor.buffer);
-            }
-        }
-        Ok(())
-    }
-}
-
-impl<'element, 'header> Render<'element, 'header>
-    for Renderer<'element, 'header, MjWrapper, MjWrapperExtra>
-{
-    fn default_attribute(&self, name: &str) -> Option<&'static str> {
-        match name {
-            "background-position" => Some("top center"),
-            "background-repeat" => Some("repeat"),
-            "background-size" => Some("auto"),
-            "direction" => Some("ltr"),
-            "padding" => Some("20px 0"),
-            "text-align" => Some("center"),
-            "text-padding" => Some("4px 4px 4px 0"),
-            _ => None,
-        }
-    }
-
-    fn context(&self) -> &'header RenderContext<'header> {
-        self.context
-    }
-
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
-        self.element.attributes.get(key).map(|v| v.as_str())
-    }
-
-    fn tag(&self) -> Option<&str> {
-        Some(NAME)
-    }
-
-    fn set_container_width(&mut self, width: Option<Pixel>) {
-        self.extra.container_width = width;
-    }
-
-    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
-        if self.is_full_width() {
-            self.render_full_width(cursor)
-        } else {
-            self.render_simple(cursor)
-        }
-    }
-}
-
-struct MjWrapperRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e MjWrapper,
-    container_width: Option<Pixel>,
-}
-
-impl<'e, 'h> MjWrapperRender<'e, 'h> {
+impl<'element, 'header> Renderer<'element, 'header, MjWrapper, ()> {
     fn current_width(&self) -> Option<Pixel> {
         self.container_width.as_ref().map(|width| {
             let hborder = self.get_border_horizontal();
@@ -123,9 +13,14 @@ impl<'e, 'h> MjWrapperRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> WithMjSectionBackground<'e, 'h> for MjWrapperRender<'e, 'h> {}
+impl<'element, 'header> WithMjSectionBackground<'element, 'header>
+    for Renderer<'element, 'header, MjWrapper, ()>
+{
+}
 
-impl<'e, 'h> SectionLikeRender<'e, 'h> for MjWrapperRender<'e, 'h> {
+impl<'element, 'header> SectionLikeRender<'element, 'header>
+    for Renderer<'element, 'header, MjWrapper, ()>
+{
     fn children(&self) -> &Vec<crate::mj_body::MjBodyChild> {
         &self.element.children
     }
@@ -166,7 +61,7 @@ impl<'e, 'h> SectionLikeRender<'e, 'h> for MjWrapperRender<'e, 'h> {
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Render<'e, 'h> for MjWrapperRender<'e, 'h> {
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjWrapper, ()> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "background-position" => Some("top center"),
@@ -180,16 +75,16 @@ impl<'r, 'e: 'r, 'h: 'r> Render<'e, 'h> for MjWrapperRender<'e, 'h> {
         }
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+    fn context(&self) -> &'header RenderContext<'header> {
+        self.context
+    }
+
+    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
         Some(NAME)
-    }
-
-    fn context(&self) -> &'h RenderContext<'h> {
-        self.context
     }
 
     fn set_container_width(&mut self, width: Option<Pixel>) {
@@ -207,7 +102,7 @@ impl<'r, 'e: 'r, 'h: 'r> Render<'e, 'h> for MjWrapperRender<'e, 'h> {
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjWrapper {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(Renderer::new(context, self, MjWrapperExtra::default()))
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mj_wrapper/render.rs
+++ b/packages/mrml-core/src/mj_wrapper/render.rs
@@ -30,11 +30,7 @@ impl<'e, 'h> SectionLikeRender<'e, 'h> for MjWrapperRender<'e, 'h> {
         &self.container_width
     }
 
-    fn render_wrapped_children(
-        &self,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_wrapped_children(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let tr = Tag::tr();
         let siblings = self.get_siblings();
         let raw_siblings = self.get_raw_siblings();
@@ -46,20 +42,20 @@ impl<'e, 'h> SectionLikeRender<'e, 'h> for MjWrapperRender<'e, 'h> {
             renderer.set_raw_siblings(raw_siblings);
             renderer.set_container_width(current_width.clone());
             if child.is_raw() {
-                renderer.render(header, buf)?;
+                renderer.render(cursor)?;
             } else {
                 let td = renderer
                     .set_style("td-outlook", Tag::td())
                     .maybe_add_attribute("align", renderer.attribute("align"))
                     .maybe_add_attribute("width", container_width.as_ref().cloned())
                     .maybe_add_suffixed_class(renderer.attribute("css-class"), "outlook");
-                tr.render_open(buf);
-                td.render_open(buf);
-                buf.end_conditional_tag();
-                renderer.render(header, buf)?;
-                buf.start_conditional_tag();
-                td.render_close(buf);
-                tr.render_close(buf);
+                tr.render_open(&mut cursor.buffer);
+                td.render_open(&mut cursor.buffer);
+                cursor.buffer.end_conditional_tag();
+                renderer.render(cursor)?;
+                cursor.buffer.start_conditional_tag();
+                td.render_close(&mut cursor.buffer);
+                tr.render_close(&mut cursor.buffer);
             }
         }
         Ok(())
@@ -96,11 +92,11 @@ impl<'r, 'e: 'r, 'h: 'r> Render<'e, 'h> for MjWrapperRender<'e, 'h> {
         self.container_width = width;
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         if self.is_full_width() {
-            self.render_full_width(header, buf)
+            self.render_full_width(cursor)
         } else {
-            self.render_simple(header, buf)
+            self.render_simple(cursor)
         }
     }
 }

--- a/packages/mrml-core/src/mj_wrapper/render.rs
+++ b/packages/mrml-core/src/mj_wrapper/render.rs
@@ -6,7 +6,6 @@ use crate::helper::condition::{END_CONDITIONAL_TAG, START_CONDITIONAL_TAG};
 use crate::helper::size::Pixel;
 use crate::helper::tag::Tag;
 use crate::mj_section::{SectionLikeRender, WithMjSectionBackground};
-use crate::prelude::hash::Map;
 use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
 
 struct MjWrapperRender<'e, 'h> {
@@ -25,9 +24,9 @@ impl<'e, 'h> MjWrapperRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> WithMjSectionBackground<'h> for MjWrapperRender<'e, 'h> {}
+impl<'e, 'h> WithMjSectionBackground<'e, 'h> for MjWrapperRender<'e, 'h> {}
 
-impl<'e, 'h> SectionLikeRender<'h> for MjWrapperRender<'e, 'h> {
+impl<'e, 'h> SectionLikeRender<'e, 'h> for MjWrapperRender<'e, 'h> {
     fn clone_header(&self) -> Rc<RefCell<Header<'h>>> {
         Rc::clone(&self.header)
     }
@@ -73,7 +72,7 @@ impl<'e, 'h> SectionLikeRender<'h> for MjWrapperRender<'e, 'h> {
     }
 }
 
-impl<'e, 'h> Render<'h> for MjWrapperRender<'e, 'h> {
+impl<'r, 'e: 'r, 'h: 'r> Render<'e, 'h> for MjWrapperRender<'e, 'h> {
     fn default_attribute(&self, name: &str) -> Option<&str> {
         match name {
             "background-position" => Some("top center"),
@@ -87,8 +86,8 @@ impl<'e, 'h> Render<'h> for MjWrapperRender<'e, 'h> {
         }
     }
 
-    fn attributes(&self) -> Option<&Map<String, String>> {
-        Some(&self.element.attributes)
+    fn raw_attribute(&self, key: &str) -> Option<&'e str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
     }
 
     fn tag(&self) -> Option<&str> {
@@ -113,7 +112,7 @@ impl<'e, 'h> Render<'h> for MjWrapperRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjWrapper {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjWrapperRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mj_wrapper/render.rs
+++ b/packages/mrml-core/src/mj_wrapper/render.rs
@@ -4,9 +4,8 @@ use std::rc::Rc;
 use super::{MjWrapper, NAME};
 use crate::helper::condition::{END_CONDITIONAL_TAG, START_CONDITIONAL_TAG};
 use crate::helper::size::Pixel;
-use crate::helper::tag::Tag;
 use crate::mj_section::{SectionLikeRender, WithMjSectionBackground};
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable, Tag};
 
 struct MjWrapperRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,

--- a/packages/mrml-core/src/mj_wrapper/render.rs
+++ b/packages/mrml-core/src/mj_wrapper/render.rs
@@ -3,6 +3,110 @@ use crate::helper::size::Pixel;
 use crate::mj_section::{SectionLikeRender, WithMjSectionBackground};
 use crate::prelude::render::*;
 
+#[derive(Default)]
+struct MjWrapperExtra {
+    container_width: Option<Pixel>,
+}
+
+impl<'element, 'header> Renderer<'element, 'header, MjWrapper, MjWrapperExtra> {
+    fn current_width(&self) -> Option<Pixel> {
+        self.extra.container_width.as_ref().map(|width| {
+            let hborder = self.get_border_horizontal();
+            let hpadding = self.get_padding_horizontal();
+            Pixel::new(width.value() - hborder.value() - hpadding.value())
+        })
+    }
+}
+
+impl<'element, 'header> WithMjSectionBackground<'element, 'header>
+    for Renderer<'element, 'header, MjWrapper, MjWrapperExtra>
+{
+}
+
+impl<'element, 'header> SectionLikeRender<'element, 'header>
+    for Renderer<'element, 'header, MjWrapper, MjWrapperExtra>
+{
+    fn children(&self) -> &Vec<crate::mj_body::MjBodyChild> {
+        &self.element.children
+    }
+
+    fn container_width(&self) -> &Option<Pixel> {
+        &self.extra.container_width
+    }
+
+    fn render_wrapped_children(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
+        let tr = Tag::tr();
+        let siblings = self.get_siblings();
+        let raw_siblings = self.get_raw_siblings();
+        let current_width = self.current_width();
+        let container_width = self.extra.container_width.as_ref().map(|v| v.to_string());
+        for child in self.children().iter() {
+            let mut renderer = child.renderer(self.context());
+            renderer.set_siblings(siblings);
+            renderer.set_raw_siblings(raw_siblings);
+            renderer.set_container_width(current_width.clone());
+            if child.is_raw() {
+                renderer.render(cursor)?;
+            } else {
+                let td = renderer
+                    .set_style("td-outlook", Tag::td())
+                    .maybe_add_attribute("align", renderer.attribute("align"))
+                    .maybe_add_attribute("width", container_width.as_ref().cloned())
+                    .maybe_add_suffixed_class(renderer.attribute("css-class"), "outlook");
+                tr.render_open(&mut cursor.buffer);
+                td.render_open(&mut cursor.buffer);
+                cursor.buffer.end_conditional_tag();
+                renderer.render(cursor)?;
+                cursor.buffer.start_conditional_tag();
+                td.render_close(&mut cursor.buffer);
+                tr.render_close(&mut cursor.buffer);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'element, 'header> Render<'element, 'header>
+    for Renderer<'element, 'header, MjWrapper, MjWrapperExtra>
+{
+    fn default_attribute(&self, name: &str) -> Option<&'static str> {
+        match name {
+            "background-position" => Some("top center"),
+            "background-repeat" => Some("repeat"),
+            "background-size" => Some("auto"),
+            "direction" => Some("ltr"),
+            "padding" => Some("20px 0"),
+            "text-align" => Some("center"),
+            "text-padding" => Some("4px 4px 4px 0"),
+            _ => None,
+        }
+    }
+
+    fn context(&self) -> &'header RenderContext<'header> {
+        self.context
+    }
+
+    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+        self.element.attributes.get(key).map(|v| v.as_str())
+    }
+
+    fn tag(&self) -> Option<&str> {
+        Some(NAME)
+    }
+
+    fn set_container_width(&mut self, width: Option<Pixel>) {
+        self.extra.container_width = width;
+    }
+
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
+        if self.is_full_width() {
+            self.render_full_width(cursor)
+        } else {
+            self.render_simple(cursor)
+        }
+    }
+}
+
 struct MjWrapperRender<'e, 'h> {
     context: &'h RenderContext<'h>,
     element: &'e MjWrapper,
@@ -103,11 +207,7 @@ impl<'r, 'e: 'r, 'h: 'r> Render<'e, 'h> for MjWrapperRender<'e, 'h> {
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjWrapper {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjWrapperRender::<'e, 'h> {
-            element: self,
-            context,
-            container_width: None,
-        })
+        Box::new(Renderer::new(context, self, MjWrapperExtra::default()))
     }
 }
 

--- a/packages/mrml-core/src/mj_wrapper/render.rs
+++ b/packages/mrml-core/src/mj_wrapper/render.rs
@@ -73,7 +73,7 @@ impl<'e, 'h> SectionLikeRender<'e, 'h> for MjWrapperRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Render<'e, 'h> for MjWrapperRender<'e, 'h> {
-    fn default_attribute(&self, name: &str) -> Option<&str> {
+    fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "background-position" => Some("top center"),
             "background-repeat" => Some("repeat"),

--- a/packages/mrml-core/src/mj_wrapper/render.rs
+++ b/packages/mrml-core/src/mj_wrapper/render.rs
@@ -3,7 +3,7 @@ use crate::helper::size::Pixel;
 use crate::mj_section::{SectionLikeRender, WithMjSectionBackground};
 use crate::prelude::render::*;
 
-impl<'element, 'header> Renderer<'element, 'header, MjWrapper, ()> {
+impl<'root> Renderer<'root, MjWrapper, ()> {
     fn current_width(&self) -> Option<Pixel> {
         self.container_width.as_ref().map(|width| {
             let hborder = self.get_border_horizontal();
@@ -13,14 +13,9 @@ impl<'element, 'header> Renderer<'element, 'header, MjWrapper, ()> {
     }
 }
 
-impl<'element, 'header> WithMjSectionBackground<'element, 'header>
-    for Renderer<'element, 'header, MjWrapper, ()>
-{
-}
+impl<'root> WithMjSectionBackground<'root> for Renderer<'root, MjWrapper, ()> {}
 
-impl<'element, 'header> SectionLikeRender<'element, 'header>
-    for Renderer<'element, 'header, MjWrapper, ()>
-{
+impl<'root> SectionLikeRender<'root> for Renderer<'root, MjWrapper, ()> {
     fn children(&self) -> &Vec<crate::mj_body::MjBodyChild> {
         &self.element.children
     }
@@ -61,7 +56,7 @@ impl<'element, 'header> SectionLikeRender<'element, 'header>
     }
 }
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, MjWrapper, ()> {
+impl<'root> Render<'root> for Renderer<'root, MjWrapper, ()> {
     fn default_attribute(&self, name: &str) -> Option<&'static str> {
         match name {
             "background-position" => Some("top center"),
@@ -75,11 +70,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
         }
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
-    fn raw_attribute(&self, key: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, key: &str) -> Option<&'root str> {
         self.element.attributes.get(key).map(|v| v.as_str())
     }
 
@@ -100,8 +95,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for MjWrapper {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for MjWrapper {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/mj_wrapper/render.rs
+++ b/packages/mrml-core/src/mj_wrapper/render.rs
@@ -2,7 +2,6 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::{MjWrapper, NAME};
-use crate::helper::condition::{END_CONDITIONAL_TAG, START_CONDITIONAL_TAG};
 use crate::helper::size::Pixel;
 use crate::mj_section::{SectionLikeRender, WithMjSectionBackground};
 use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable, Tag};
@@ -63,9 +62,9 @@ impl<'e, 'h> SectionLikeRender<'e, 'h> for MjWrapperRender<'e, 'h> {
                     .maybe_add_suffixed_class(renderer.attribute("css-class"), "outlook");
                 tr.render_open(buf);
                 td.render_open(buf);
-                buf.push_str(END_CONDITIONAL_TAG);
+                buf.end_conditional_tag();
                 renderer.render(opts, buf)?;
-                buf.push_str(START_CONDITIONAL_TAG);
+                buf.start_conditional_tag();
                 td.render_close(buf);
                 tr.render_close(buf);
             }

--- a/packages/mrml-core/src/mjml/render.rs
+++ b/packages/mrml-core/src/mjml/render.rs
@@ -2,13 +2,8 @@ use super::Mjml;
 use crate::mj_head::MjHead;
 use crate::prelude::render::*;
 
-pub struct MjmlRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e Mjml,
-}
-
-impl<'e, 'h> Render<'e, 'h> for MjmlRender<'e, 'h> {
-    fn context(&self) -> &'h RenderContext<'h> {
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, Mjml, ()> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
@@ -41,10 +36,7 @@ impl<'e, 'h> Render<'e, 'h> for MjmlRender<'e, 'h> {
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for Mjml {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(MjmlRender::<'e, 'h> {
-            element: self,
-            context,
-        })
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/mjml/render.rs
+++ b/packages/mrml-core/src/mjml/render.rs
@@ -10,7 +10,7 @@ pub struct MjmlRender<'e, 'h> {
     element: &'e Mjml,
 }
 
-impl<'e, 'h> Render<'h> for MjmlRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for MjmlRender<'e, 'h> {
     fn header(&self) -> Ref<Header<'h>> {
         self.header.borrow()
     }
@@ -45,7 +45,7 @@ impl<'e, 'h> Render<'h> for MjmlRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for Mjml {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(MjmlRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/mjml/render.rs
+++ b/packages/mrml-core/src/mjml/render.rs
@@ -38,7 +38,7 @@ impl<'e, 'h> Render<'e, 'h> for MjmlRender<'e, 'h> {
                 .renderer(Rc::clone(&self.header))
                 .render(opts, buf)?;
         }
-        buf.push_str(body_buf.as_str());
+        buf.push_str(body_buf.as_ref());
         buf.push_str("</html>");
         Ok(())
     }
@@ -60,7 +60,7 @@ impl Mjml {
         let header = Rc::new(RefCell::new(header));
         let mut buf = RenderBuffer::default();
         self.renderer(header).render(opts, &mut buf)?;
-        Ok(buf)
+        Ok(buf.into())
     }
 
     pub fn get_title(&self) -> Option<String> {

--- a/packages/mrml-core/src/mjml/render.rs
+++ b/packages/mrml-core/src/mjml/render.rs
@@ -2,8 +2,8 @@ use super::Mjml;
 use crate::mj_head::MjHead;
 use crate::prelude::render::*;
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, Mjml, ()> {
-    fn context(&self) -> &'header RenderContext<'header> {
+impl<'root> Render<'root> for Renderer<'root, Mjml, ()> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -34,8 +34,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for Mjml {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for Mjml {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/node/render.rs
+++ b/packages/mrml-core/src/node/render.rs
@@ -2,16 +2,15 @@ use super::Node;
 use crate::prelude::is_void_element;
 use crate::prelude::render::*;
 
-impl<'render, 'element: 'render, 'header: 'render, T> Render<'element, 'header>
-    for Renderer<'element, 'header, Node<T>, ()>
+impl<'render, 'root: 'render, T> Render<'root> for Renderer<'root, Node<T>, ()>
 where
-    T: Renderable<'render, 'element, 'header>,
+    T: Renderable<'render, 'root>,
 {
     fn tag(&self) -> Option<&str> {
         Some(self.element.tag.as_str())
     }
 
-    fn context(&self) -> &'header RenderContext<'header> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -49,8 +48,13 @@ where
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r, T: Renderable<'r, 'e, 'h>> Renderable<'r, 'e, 'h> for Node<T> {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render, T: Renderable<'render, 'root>> Renderable<'render, 'root>
+    for Node<T>
+{
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/node/render.rs
+++ b/packages/mrml-core/src/node/render.rs
@@ -2,20 +2,16 @@ use super::Node;
 use crate::prelude::is_void_element;
 use crate::prelude::render::*;
 
-struct NodeRender<'e, 'h, T> {
-    context: &'h RenderContext<'h>,
-    element: &'e Node<T>,
-}
-
-impl<'r, 'e: 'r, 'h: 'r, T> Render<'e, 'h> for NodeRender<'e, 'h, T>
+impl<'render, 'element: 'render, 'header: 'render, T> Render<'element, 'header>
+    for Renderer<'element, 'header, Node<T>, ()>
 where
-    T: Renderable<'r, 'e, 'h>,
+    T: Renderable<'render, 'element, 'header>,
 {
     fn tag(&self) -> Option<&str> {
         Some(self.element.tag.as_str())
     }
 
-    fn context(&self) -> &'h RenderContext<'h> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
@@ -55,10 +51,7 @@ where
 
 impl<'r, 'e: 'r, 'h: 'r, T: Renderable<'r, 'e, 'h>> Renderable<'r, 'e, 'h> for Node<T> {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(NodeRender::<'e, 'h> {
-            element: self,
-            context,
-        })
+        Box::new(Renderer::new(context, self, ()))
     }
 }
 

--- a/packages/mrml-core/src/node/render.rs
+++ b/packages/mrml-core/src/node/render.rs
@@ -3,7 +3,7 @@ use crate::prelude::is_void_element;
 use crate::prelude::render::*;
 
 struct NodeRender<'e, 'h, T> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e Node<T>,
 }
 
@@ -15,16 +15,11 @@ where
         Some(self.element.tag.as_str())
     }
 
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        self.context
     }
 
-    fn render(
-        &self,
-        opts: &RenderOptions,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
         buf.push('<');
         buf.push_str(&self.element.tag);
         for (key, value) in self.element.attributes.iter() {
@@ -46,9 +41,9 @@ where
             buf.push('>');
             for (index, child) in self.element.children.iter().enumerate() {
                 // TODO children
-                let mut renderer = child.renderer(self.header);
+                let mut renderer = child.renderer(self.context);
                 renderer.set_index(index);
-                renderer.render(opts, header, buf)?;
+                renderer.render(header, buf)?;
             }
             buf.push_str("</");
             buf.push_str(&self.element.tag);
@@ -59,10 +54,10 @@ where
 }
 
 impl<'r, 'e: 'r, 'h: 'r, T: Renderable<'r, 'e, 'h>> Renderable<'r, 'e, 'h> for Node<T> {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(NodeRender::<'e, 'h> {
             element: self,
-            header,
+            context,
         })
     }
 }

--- a/packages/mrml-core/src/node/render.rs
+++ b/packages/mrml-core/src/node/render.rs
@@ -19,35 +19,35 @@ where
         self.context
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
-        buf.push('<');
-        buf.push_str(&self.element.tag);
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
+        cursor.buffer.push('<');
+        cursor.buffer.push_str(&self.element.tag);
         for (key, value) in self.element.attributes.iter() {
-            buf.push(' ');
-            buf.push_str(key);
-            buf.push_str("=\"");
-            buf.push_str(value);
-            buf.push('"');
+            cursor.buffer.push(' ');
+            cursor.buffer.push_str(key);
+            cursor.buffer.push_str("=\"");
+            cursor.buffer.push_str(value);
+            cursor.buffer.push('"');
         }
         if self.element.children.is_empty() {
             if is_void_element(self.element.tag.as_str()) {
-                buf.push_str(" />");
+                cursor.buffer.push_str(" />");
             } else {
-                buf.push_str("></");
-                buf.push_str(&self.element.tag);
-                buf.push('>');
+                cursor.buffer.push_str("></");
+                cursor.buffer.push_str(&self.element.tag);
+                cursor.buffer.push('>');
             }
         } else {
-            buf.push('>');
+            cursor.buffer.push('>');
             for (index, child) in self.element.children.iter().enumerate() {
                 // TODO children
                 let mut renderer = child.renderer(self.context);
                 renderer.set_index(index);
-                renderer.render(header, buf)?;
+                renderer.render(cursor)?;
             }
-            buf.push_str("</");
-            buf.push_str(&self.element.tag);
-            buf.push('>');
+            cursor.buffer.push_str("</");
+            cursor.buffer.push_str(&self.element.tag);
+            cursor.buffer.push('>');
         }
         Ok(())
     }

--- a/packages/mrml-core/src/node/render.rs
+++ b/packages/mrml-core/src/node/render.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use super::Node;
 use crate::prelude::is_void_element;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable};
 
 struct NodeRender<'e, 'h, T> {
     header: Rc<RefCell<Header<'h>>>,
@@ -22,8 +22,8 @@ where
         self.header.borrow()
     }
 
-    fn render(&self, opts: &RenderOptions) -> Result<String, Error> {
-        let mut buf = String::from("<");
+    fn render(&self, opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
+        buf.push('<');
         buf.push_str(&self.element.tag);
         for (key, value) in self.element.attributes.iter() {
             buf.push(' ');
@@ -46,13 +46,13 @@ where
                 // TODO children
                 let mut renderer = child.renderer(Rc::clone(&self.header));
                 renderer.set_index(index);
-                buf.push_str(&renderer.render(opts)?);
+                renderer.render(opts, buf)?;
             }
             buf.push_str("</");
             buf.push_str(&self.element.tag);
             buf.push('>');
         }
-        Ok(buf)
+        Ok(())
     }
 }
 

--- a/packages/mrml-core/src/node/render.rs
+++ b/packages/mrml-core/src/node/render.rs
@@ -10,7 +10,7 @@ struct NodeRender<'e, 'h, T> {
     element: &'e Node<T>,
 }
 
-impl<'r, 'e: 'r, 'h: 'r, T> Render<'h> for NodeRender<'e, 'h, T>
+impl<'r, 'e: 'r, 'h: 'r, T> Render<'e, 'h> for NodeRender<'e, 'h, T>
 where
     T: Renderable<'r, 'e, 'h>,
 {
@@ -57,7 +57,7 @@ where
 }
 
 impl<'r, 'e: 'r, 'h: 'r, T: Renderable<'r, 'e, 'h>> Renderable<'r, 'e, 'h> for Node<T> {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(NodeRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/prelude/render.rs
+++ b/packages/mrml-core/src/prelude/render.rs
@@ -312,7 +312,7 @@ pub trait Render<'element, 'header> {
         self.attribute_as_size("width")
     }
 
-    fn default_attribute(&self, _key: &str) -> Option<&str> {
+    fn default_attribute(&self, _key: &str) -> Option<&'static str> {
         None
     }
 

--- a/packages/mrml-core/src/prelude/render/buffer.rs
+++ b/packages/mrml-core/src/prelude/render/buffer.rs
@@ -15,6 +15,45 @@ impl RenderBuffer {
     }
 }
 
+const START_CONDITIONAL_TAG: &str = "<!--[if mso | IE]>";
+const START_MSO_CONDITIONAL_TAG: &str = "<!--[if mso]>";
+const END_CONDITIONAL_TAG: &str = "<![endif]-->";
+const START_NEGATION_CONDITIONAL_TAG: &str = "<!--[if !mso | IE]><!-->";
+const START_MSO_NEGATION_CONDITIONAL_TAG: &str = "<!--[if !mso]><!-->";
+const END_NEGATION_CONDITIONAL_TAG: &str = "<!--<![endif]-->";
+
+impl RenderBuffer {
+    #[inline]
+    pub fn start_conditional_tag(&mut self) {
+        self.inner.push_str(START_CONDITIONAL_TAG);
+    }
+
+    #[inline]
+    pub fn start_negation_conditional_tag(&mut self) {
+        self.inner.push_str(START_NEGATION_CONDITIONAL_TAG);
+    }
+
+    #[inline]
+    pub fn start_mso_conditional_tag(&mut self) {
+        self.inner.push_str(START_MSO_CONDITIONAL_TAG);
+    }
+
+    #[inline]
+    pub fn start_mso_negation_conditional_tag(&mut self) {
+        self.inner.push_str(START_MSO_NEGATION_CONDITIONAL_TAG);
+    }
+
+    #[inline]
+    pub fn end_conditional_tag(&mut self) {
+        self.inner.push_str(END_CONDITIONAL_TAG);
+    }
+
+    #[inline]
+    pub fn end_negation_conditional_tag(&mut self) {
+        self.inner.push_str(END_NEGATION_CONDITIONAL_TAG);
+    }
+}
+
 impl AsRef<str> for RenderBuffer {
     fn as_ref(&self) -> &str {
         self.inner.as_str()

--- a/packages/mrml-core/src/prelude/render/buffer.rs
+++ b/packages/mrml-core/src/prelude/render/buffer.rs
@@ -1,0 +1,28 @@
+#[derive(Debug, Default)]
+pub struct RenderBuffer {
+    inner: String,
+}
+
+impl RenderBuffer {
+    #[inline]
+    pub fn push_str(&mut self, value: &str) {
+        self.inner.push_str(value);
+    }
+
+    #[inline]
+    pub fn push(&mut self, value: char) {
+        self.inner.push(value);
+    }
+}
+
+impl AsRef<str> for RenderBuffer {
+    fn as_ref(&self) -> &str {
+        self.inner.as_str()
+    }
+}
+
+impl From<RenderBuffer> for String {
+    fn from(value: RenderBuffer) -> Self {
+        value.inner
+    }
+}

--- a/packages/mrml-core/src/prelude/render/header.rs
+++ b/packages/mrml-core/src/prelude/render/header.rs
@@ -1,0 +1,146 @@
+use std::borrow::Cow;
+use std::convert::TryFrom;
+use std::sync::atomic::{AtomicU16, Ordering};
+
+use crate::helper::size::{Pixel, Size};
+use crate::mj_head::MjHead;
+use crate::prelude::hash::Map;
+use crate::prelude::hash::Set;
+
+pub struct Header<'h> {
+    head: &'h Option<MjHead>,
+    attributes_all: Map<&'h str, &'h str>,
+    attributes_class: Map<&'h str, Map<&'h str, &'h str>>,
+    attributes_element: Map<&'h str, Map<&'h str, &'h str>>,
+    breakpoint: Pixel,
+    font_families: Map<&'h str, &'h str>,
+    used_font_families: Set<String>,
+    media_queries: Map<String, Size>,
+    styles: Set<Cow<'static, str>>,
+    lang: Option<String>,
+    generator: AtomicU16,
+}
+
+impl<'h> Header<'h> {
+    pub fn new(head: &'h Option<MjHead>) -> Self {
+        Self {
+            head,
+            attributes_all: head
+                .as_ref()
+                .map(|h| h.build_attributes_all())
+                .unwrap_or_default(),
+            attributes_class: head
+                .as_ref()
+                .map(|h| h.build_attributes_class())
+                .unwrap_or_default(),
+            attributes_element: head
+                .as_ref()
+                .map(|h| h.build_attributes_element())
+                .unwrap_or_default(),
+            breakpoint: head
+                .as_ref()
+                .and_then(|h| h.breakpoint())
+                .and_then(|s| Pixel::try_from(s.value()).ok())
+                .unwrap_or_else(|| Pixel::new(480.0)),
+            font_families: head
+                .as_ref()
+                .map(|h| h.build_font_families())
+                .unwrap_or_default(),
+            used_font_families: Set::new(),
+            media_queries: Map::new(),
+            styles: Set::new(),
+            lang: Default::default(),
+            generator: AtomicU16::new(0),
+        }
+    }
+
+    pub fn attribute_all(&self, key: &str) -> Option<&str> {
+        self.attributes_all.get(key).copied()
+    }
+
+    pub fn attribute_class(&self, name: &str, key: &str) -> Option<&str> {
+        self.attributes_class
+            .get(name)
+            .and_then(|class_map| class_map.get(key))
+            .copied()
+    }
+
+    pub fn attribute_element(&self, name: &str, key: &str) -> Option<&str> {
+        self.attributes_element
+            .get(name)
+            .and_then(|elt| elt.get(key))
+            .copied()
+    }
+
+    pub fn head(&self) -> &Option<MjHead> {
+        self.head
+    }
+
+    pub fn breakpoint(&self) -> &Pixel {
+        &self.breakpoint
+    }
+
+    pub fn add_used_font_family(&mut self, value: &str) {
+        self.used_font_families.insert(value.to_string());
+    }
+
+    pub fn add_font_families<T: AsRef<str>>(&mut self, value: T) {
+        for name in value
+            .as_ref()
+            .split(',')
+            .map(|item| item.trim())
+            .filter(|item| !item.is_empty())
+        {
+            self.add_used_font_family(name);
+        }
+    }
+
+    pub fn maybe_add_font_families<T: AsRef<str>>(&mut self, value: Option<T>) {
+        if let Some(value) = value {
+            self.add_font_families(value);
+        }
+    }
+
+    pub fn used_font_families(&self) -> &Set<String> {
+        &self.used_font_families
+    }
+
+    pub fn font_families(&self) -> &Map<&str, &str> {
+        &self.font_families
+    }
+
+    pub fn media_queries(&self) -> &Map<String, Size> {
+        &self.media_queries
+    }
+
+    pub fn add_media_query(&mut self, classname: String, size: Size) {
+        self.media_queries.insert(classname, size);
+    }
+
+    pub fn styles(&self) -> &Set<Cow<'static, str>> {
+        &self.styles
+    }
+
+    pub fn add_style<V: Into<Cow<'static, str>>>(&mut self, value: V) {
+        self.styles.insert(value.into());
+    }
+
+    pub fn maybe_add_style<V: Into<Cow<'static, str>>>(&mut self, value: Option<V>) {
+        if let Some(value) = value {
+            self.add_style(value);
+        }
+    }
+
+    pub fn lang(&self) -> Option<&str> {
+        self.lang.as_deref()
+    }
+
+    pub fn maybe_set_lang(&mut self, value: Option<String>) {
+        self.lang = value;
+    }
+
+    pub fn next_id(&self) -> String {
+        let id = self.generator.fetch_add(1, Ordering::SeqCst);
+        format!("{id:0>8}")
+    }
+}

--- a/packages/mrml-core/src/prelude/render/header.rs
+++ b/packages/mrml-core/src/prelude/render/header.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::convert::TryFrom;
-use std::sync::atomic::{AtomicU16, Ordering};
 
 use crate::helper::size::{Pixel, Size};
 use crate::mj_head::MjHead;
@@ -81,7 +80,6 @@ pub struct Header<'h> {
     title: Option<&'h str>,
     preview: Option<&'h str>,
     lang: Option<&'h str>,
-    generator: AtomicU16,
 }
 
 impl<'h> Header<'h> {
@@ -111,7 +109,6 @@ impl<'h> Header<'h> {
             title: head.and_then(|h| h.title().map(|t| t.content())),
             preview: head.and_then(|h| h.preview().map(|t| t.content())),
             lang,
-            generator: AtomicU16::new(0),
         }
     }
 
@@ -151,10 +148,5 @@ impl<'h> Header<'h> {
 
     pub fn preview(&self) -> Option<&str> {
         self.preview
-    }
-
-    pub fn next_id(&self) -> String {
-        let id = self.generator.fetch_add(1, Ordering::SeqCst);
-        format!("{id:0>8}")
     }
 }

--- a/packages/mrml-core/src/prelude/render/header.rs
+++ b/packages/mrml-core/src/prelude/render/header.rs
@@ -6,6 +6,7 @@ use crate::mj_head::MjHead;
 use crate::prelude::hash::Map;
 use crate::prelude::hash::Set;
 
+#[derive(Debug)]
 pub struct VariableHeader {
     used_font_families: Set<String>,
     media_queries: Map<String, Size>,

--- a/packages/mrml-core/src/prelude/render/mod.rs
+++ b/packages/mrml-core/src/prelude/render/mod.rs
@@ -55,9 +55,9 @@ pub struct RenderCursor {
     pub header: VariableHeader,
 }
 
-pub(crate) struct Renderer<'element, 'header, Element, Extra> {
-    pub context: &'header RenderContext<'header>,
-    pub element: &'element Element,
+pub(crate) struct Renderer<'root, Element, Extra> {
+    pub context: &'root RenderContext<'root>,
+    pub element: &'root Element,
     pub container_width: Option<Pixel>,
     pub siblings: usize,
     pub raw_siblings: usize,
@@ -65,11 +65,11 @@ pub(crate) struct Renderer<'element, 'header, Element, Extra> {
     pub extra: Extra,
 }
 
-impl<'element, 'header, Element, Extra> Renderer<'element, 'header, Element, Extra> {
+impl<'root, Element, Extra> Renderer<'root, Element, Extra> {
     #[inline]
     pub fn new(
-        context: &'header RenderContext<'header>,
-        element: &'element Element,
+        context: &'root RenderContext<'root>,
+        element: &'root Element,
         extra: Extra,
     ) -> Self {
         Self {
@@ -84,14 +84,14 @@ impl<'element, 'header, Element, Extra> Renderer<'element, 'header, Element, Ext
     }
 }
 
-pub trait Render<'element, 'header> {
-    fn context(&self) -> &'header RenderContext<'header>;
+pub trait Render<'root> {
+    fn context(&self) -> &'root RenderContext<'root>;
 
     fn tag(&self) -> Option<&str> {
         None
     }
 
-    fn raw_attribute(&self, _: &str) -> Option<&'element str> {
+    fn raw_attribute(&self, _: &str) -> Option<&'root str> {
         None
     }
 
@@ -268,15 +268,15 @@ pub trait Render<'element, 'header> {
     fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error>;
 }
 
-pub trait Renderable<'render, 'element: 'render, 'header: 'render> {
-    fn is_raw(&'element self) -> bool {
+pub trait Renderable<'render, 'root: 'render> {
+    fn is_raw(&'root self) -> bool {
         false
     }
 
     fn renderer(
-        &'element self,
-        context: &'header RenderContext<'header>,
-    ) -> Box<dyn Render<'element, 'header> + 'render>;
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render>;
 }
 
 #[cfg(test)]

--- a/packages/mrml-core/src/prelude/render/mod.rs
+++ b/packages/mrml-core/src/prelude/render/mod.rs
@@ -95,7 +95,7 @@ pub trait Render<'root> {
         None
     }
 
-    fn raw_extra_attribute(&self, _: &str) -> Option<&str> {
+    fn raw_extra_attribute(&self, _: &str) -> Option<&'root str> {
         None
     }
 
@@ -253,9 +253,9 @@ pub trait Render<'root> {
     fn set_siblings(&mut self, _count: usize) {}
     fn set_raw_siblings(&mut self, _count: usize) {}
 
-    fn add_extra_attribute(&mut self, _key: &str, _value: &str) {}
-    fn maybe_add_extra_attribute(&mut self, key: &str, value: Option<String>) {
-        if let Some(ref value) = value {
+    fn add_extra_attribute(&mut self, _key: &'root str, _value: &'root str) {}
+    fn maybe_add_extra_attribute(&mut self, key: &'root str, value: Option<&'root str>) {
+        if let Some(value) = value {
             self.add_extra_attribute(key, value);
         }
     }

--- a/packages/mrml-core/src/prelude/render/mod.rs
+++ b/packages/mrml-core/src/prelude/render/mod.rs
@@ -49,6 +49,12 @@ impl<'h> RenderContext<'h> {
     }
 }
 
+#[derive(Debug, Default)]
+pub struct RenderCursor {
+    pub buffer: RenderBuffer,
+    pub header: VariableHeader,
+}
+
 pub trait Render<'element, 'header> {
     fn context(&self) -> &'header RenderContext<'header>;
 
@@ -223,19 +229,14 @@ pub trait Render<'element, 'header> {
         }
     }
 
-    fn render_fragment(
-        &self,
-        name: &str,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render_fragment(&self, name: &str, cursor: &mut RenderCursor) -> Result<(), Error> {
         match name {
-            "main" => self.render(header, buf),
+            "main" => self.render(cursor),
             _ => Err(Error::UnknownFragment(name.to_string())),
         }
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error>;
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error>;
 }
 
 pub trait Renderable<'render, 'element: 'render, 'header: 'render> {

--- a/packages/mrml-core/src/prelude/render/mod.rs
+++ b/packages/mrml-core/src/prelude/render/mod.rs
@@ -5,10 +5,12 @@ use std::rc::Rc;
 use crate::helper::size::{Pixel, Size};
 use crate::helper::spacing::Spacing;
 
+mod buffer;
 mod header;
 mod options;
 mod tag;
 
+pub use buffer::*;
 pub use header::*;
 pub use options::*;
 pub use tag::*;
@@ -18,8 +20,6 @@ pub enum Error {
     #[error("unknown fragment {0}")]
     UnknownFragment(String),
 }
-
-pub type RenderBuffer = String;
 
 #[deprecated = "use mrml::prelude::render::RenderOptions instead"]
 pub type Options = RenderOptions;

--- a/packages/mrml-core/src/prelude/render/mod.rs
+++ b/packages/mrml-core/src/prelude/render/mod.rs
@@ -55,6 +55,27 @@ pub struct RenderCursor {
     pub header: VariableHeader,
 }
 
+pub(crate) struct Renderer<'element, 'header, Element, Extra> {
+    pub context: &'header RenderContext<'header>,
+    pub element: &'element Element,
+    pub extra: Extra,
+}
+
+impl<'element, 'header, Element, Extra> Renderer<'element, 'header, Element, Extra> {
+    #[inline]
+    pub fn new(
+        context: &'header RenderContext<'header>,
+        element: &'element Element,
+        extra: Extra,
+    ) -> Self {
+        Self {
+            context,
+            element,
+            extra,
+        }
+    }
+}
+
 pub trait Render<'element, 'header> {
     fn context(&self) -> &'header RenderContext<'header>;
 

--- a/packages/mrml-core/src/prelude/render/mod.rs
+++ b/packages/mrml-core/src/prelude/render/mod.rs
@@ -58,6 +58,7 @@ pub struct RenderCursor {
 pub(crate) struct Renderer<'element, 'header, Element, Extra> {
     pub context: &'header RenderContext<'header>,
     pub element: &'element Element,
+    pub container_width: Option<Pixel>,
     pub extra: Extra,
 }
 
@@ -71,6 +72,7 @@ impl<'element, 'header, Element, Extra> Renderer<'element, 'header, Element, Ext
         Self {
             context,
             element,
+            container_width: None,
             extra,
         }
     }

--- a/packages/mrml-core/src/prelude/render/mod.rs
+++ b/packages/mrml-core/src/prelude/render/mod.rs
@@ -1,16 +1,17 @@
-use std::borrow::Cow;
 use std::cell::{Ref, RefCell};
-use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicU16, Ordering};
 
-use super::hash::Set;
 use crate::helper::size::{Pixel, Size};
 use crate::helper::spacing::Spacing;
-use crate::helper::tag::Tag;
-use crate::mj_head::MjHead;
-use crate::prelude::hash::Map;
+
+mod header;
+mod options;
+mod tag;
+
+pub use header::*;
+pub use options::*;
+pub use tag::*;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -18,184 +19,10 @@ pub enum Error {
     UnknownFragment(String),
 }
 
+pub type RenderBuffer = String;
+
 #[deprecated = "use mrml::prelude::render::RenderOptions instead"]
 pub type Options = RenderOptions;
-
-#[derive(Debug)]
-pub struct RenderOptions {
-    pub disable_comments: bool,
-    pub social_icon_origin: Option<Cow<'static, str>>,
-    pub fonts: HashMap<String, Cow<'static, str>>,
-}
-
-impl Default for RenderOptions {
-    fn default() -> Self {
-        Self {
-            disable_comments: false,
-            social_icon_origin: None,
-            fonts: HashMap::from([
-                (
-                    "Open Sans".into(),
-                    "https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700".into(),
-                ),
-                (
-                    "Droid Sans".into(),
-                    "https://fonts.googleapis.com/css?family=Droid+Sans:300,400,500,700".into(),
-                ),
-                (
-                    "Lato".into(),
-                    "https://fonts.googleapis.com/css?family=Lato:300,400,500,700".into(),
-                ),
-                (
-                    "Roboto".into(),
-                    "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700".into(),
-                ),
-                (
-                    "Ubuntu".into(),
-                    "https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700".into(),
-                ),
-            ]),
-        }
-    }
-}
-
-pub struct Header<'h> {
-    head: &'h Option<MjHead>,
-    attributes_all: Map<&'h str, &'h str>,
-    attributes_class: Map<&'h str, Map<&'h str, &'h str>>,
-    attributes_element: Map<&'h str, Map<&'h str, &'h str>>,
-    breakpoint: Pixel,
-    font_families: Map<&'h str, &'h str>,
-    used_font_families: Set<String>,
-    media_queries: Map<String, Size>,
-    styles: Set<Cow<'static, str>>,
-    lang: Option<String>,
-    generator: AtomicU16,
-}
-
-impl<'h> Header<'h> {
-    pub fn new(head: &'h Option<MjHead>) -> Self {
-        Self {
-            head,
-            attributes_all: head
-                .as_ref()
-                .map(|h| h.build_attributes_all())
-                .unwrap_or_default(),
-            attributes_class: head
-                .as_ref()
-                .map(|h| h.build_attributes_class())
-                .unwrap_or_default(),
-            attributes_element: head
-                .as_ref()
-                .map(|h| h.build_attributes_element())
-                .unwrap_or_default(),
-            breakpoint: head
-                .as_ref()
-                .and_then(|h| h.breakpoint())
-                .and_then(|s| Pixel::try_from(s.value()).ok())
-                .unwrap_or_else(|| Pixel::new(480.0)),
-            font_families: head
-                .as_ref()
-                .map(|h| h.build_font_families())
-                .unwrap_or_default(),
-            used_font_families: Set::new(),
-            media_queries: Map::new(),
-            styles: Set::new(),
-            lang: Default::default(),
-            generator: AtomicU16::new(0),
-        }
-    }
-
-    pub fn attribute_all(&self, key: &str) -> Option<&str> {
-        self.attributes_all.get(key).copied()
-    }
-
-    pub fn attribute_class(&self, name: &str, key: &str) -> Option<&str> {
-        self.attributes_class
-            .get(name)
-            .and_then(|class_map| class_map.get(key))
-            .copied()
-    }
-
-    pub fn attribute_element(&self, name: &str, key: &str) -> Option<&str> {
-        self.attributes_element
-            .get(name)
-            .and_then(|elt| elt.get(key))
-            .copied()
-    }
-
-    pub fn head(&self) -> &Option<MjHead> {
-        self.head
-    }
-
-    pub fn breakpoint(&self) -> &Pixel {
-        &self.breakpoint
-    }
-
-    pub fn add_used_font_family(&mut self, value: &str) {
-        self.used_font_families.insert(value.to_string());
-    }
-
-    pub fn add_font_families<T: AsRef<str>>(&mut self, value: T) {
-        for name in value
-            .as_ref()
-            .split(',')
-            .map(|item| item.trim())
-            .filter(|item| !item.is_empty())
-        {
-            self.add_used_font_family(name);
-        }
-    }
-
-    pub fn maybe_add_font_families<T: AsRef<str>>(&mut self, value: Option<T>) {
-        if let Some(value) = value {
-            self.add_font_families(value);
-        }
-    }
-
-    pub fn used_font_families(&self) -> &Set<String> {
-        &self.used_font_families
-    }
-
-    pub fn font_families(&self) -> &Map<&str, &str> {
-        &self.font_families
-    }
-
-    pub fn media_queries(&self) -> &Map<String, Size> {
-        &self.media_queries
-    }
-
-    pub fn add_media_query(&mut self, classname: String, size: Size) {
-        self.media_queries.insert(classname, size);
-    }
-
-    pub fn styles(&self) -> &Set<Cow<'static, str>> {
-        &self.styles
-    }
-
-    pub fn add_style<V: Into<Cow<'static, str>>>(&mut self, value: V) {
-        self.styles.insert(value.into());
-    }
-
-    pub fn maybe_add_style<V: Into<Cow<'static, str>>>(&mut self, value: Option<V>) {
-        if let Some(value) = value {
-            self.add_style(value);
-        }
-    }
-
-    pub fn lang(&self) -> Option<&str> {
-        self.lang.as_deref()
-    }
-
-    pub fn maybe_set_lang(&mut self, value: Option<String>) {
-        self.lang = value;
-    }
-
-    pub fn next_id(&self) -> String {
-        let id = self.generator.fetch_add(1, Ordering::SeqCst);
-        format!("{id:0>8}")
-    }
-}
 
 pub trait Render<'element, 'header> {
     fn header(&self) -> Ref<Header<'header>>;

--- a/packages/mrml-core/src/prelude/render/mod.rs
+++ b/packages/mrml-core/src/prelude/render/mod.rs
@@ -197,14 +197,19 @@ pub trait Render<'element, 'header> {
         }
     }
 
-    fn render_fragment(&self, name: &str, opts: &RenderOptions) -> Result<String, Error> {
+    fn render_fragment(
+        &self,
+        name: &str,
+        opts: &RenderOptions,
+        buf: &mut RenderBuffer,
+    ) -> Result<(), Error> {
         match name {
-            "main" => self.render(opts),
+            "main" => self.render(opts, buf),
             _ => Err(Error::UnknownFragment(name.to_string())),
         }
     }
 
-    fn render(&self, opts: &RenderOptions) -> Result<String, Error>;
+    fn render(&self, opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error>;
 }
 
 pub trait Renderable<'render, 'element: 'render, 'header: 'render> {

--- a/packages/mrml-core/src/prelude/render/mod.rs
+++ b/packages/mrml-core/src/prelude/render/mod.rs
@@ -59,6 +59,9 @@ pub(crate) struct Renderer<'element, 'header, Element, Extra> {
     pub context: &'header RenderContext<'header>,
     pub element: &'element Element,
     pub container_width: Option<Pixel>,
+    pub siblings: usize,
+    pub raw_siblings: usize,
+    pub index: usize,
     pub extra: Extra,
 }
 
@@ -73,6 +76,9 @@ impl<'element, 'header, Element, Extra> Renderer<'element, 'header, Element, Ext
             context,
             element,
             container_width: None,
+            siblings: 1,
+            raw_siblings: 0,
+            index: 0,
             extra,
         }
     }

--- a/packages/mrml-core/src/prelude/render/mod.rs
+++ b/packages/mrml-core/src/prelude/render/mod.rs
@@ -181,7 +181,7 @@ pub trait Render<'element, 'header> {
             .and_then(|value| Pixel::try_from(value.as_str()).ok())
     }
 
-    fn set_style(&self, _name: &str, tag: Tag) -> Tag {
+    fn set_style<'a>(&self, _name: &str, tag: Tag<'a>) -> Tag<'a> {
         tag
     }
 

--- a/packages/mrml-core/src/prelude/render/options.rs
+++ b/packages/mrml-core/src/prelude/render/options.rs
@@ -1,0 +1,44 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+pub fn default_fonts() -> HashMap<String, Cow<'static, str>> {
+    HashMap::from([
+        (
+            "Open Sans".into(),
+            "https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700".into(),
+        ),
+        (
+            "Droid Sans".into(),
+            "https://fonts.googleapis.com/css?family=Droid+Sans:300,400,500,700".into(),
+        ),
+        (
+            "Lato".into(),
+            "https://fonts.googleapis.com/css?family=Lato:300,400,500,700".into(),
+        ),
+        (
+            "Roboto".into(),
+            "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700".into(),
+        ),
+        (
+            "Ubuntu".into(),
+            "https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700".into(),
+        ),
+    ])
+}
+
+#[derive(Debug)]
+pub struct RenderOptions {
+    pub disable_comments: bool,
+    pub social_icon_origin: Option<Cow<'static, str>>,
+    pub fonts: HashMap<String, Cow<'static, str>>,
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self {
+            disable_comments: false,
+            social_icon_origin: None,
+            fonts: default_fonts(),
+        }
+    }
+}

--- a/packages/mrml-core/src/prelude/render/tag.rs
+++ b/packages/mrml-core/src/prelude/render/tag.rs
@@ -190,6 +190,12 @@ impl Tag {
         self.render_close(buf);
     }
 
+    pub fn render_text(&self, buf: &mut RenderBuffer, value: &str) {
+        self.render_open(buf);
+        buf.push_str(value);
+        self.render_close(buf);
+    }
+
     pub fn render<T: AsRef<str>>(&self, input: T) -> String {
         let mut buf = String::default();
         self.render_open(&mut buf);

--- a/packages/mrml-core/src/prelude/render/tag.rs
+++ b/packages/mrml-core/src/prelude/render/tag.rs
@@ -3,15 +3,15 @@ use std::borrow::Cow;
 use super::RenderBuffer;
 use crate::prelude::hash::{Map, Set};
 
-pub struct Tag {
-    name: Cow<'static, str>,
-    attributes: Map<Cow<'static, str>, Cow<'static, str>>,
-    classes: Set<Cow<'static, str>>,
+pub struct Tag<'a> {
+    name: Cow<'a, str>,
+    attributes: Map<Cow<'a, str>, Cow<'a, str>>,
+    classes: Set<Cow<'a, str>>,
     // in order to keep the style in the same order the've been added
-    styles: Vec<(Cow<'static, str>, Cow<'static, str>)>,
+    styles: Vec<(Cow<'a, str>, Cow<'a, str>)>,
 }
 
-impl Tag {
+impl<'a> Tag<'a> {
     pub fn table() -> Self {
         Self::new("table")
     }
@@ -37,7 +37,7 @@ impl Tag {
         Self::new("div")
     }
 
-    pub fn new<N: Into<Cow<'static, str>>>(name: N) -> Self {
+    pub fn new<N: Into<Cow<'a, str>>>(name: N) -> Self {
         Self {
             name: name.into(),
             attributes: Map::new(),
@@ -46,7 +46,7 @@ impl Tag {
         }
     }
 
-    pub fn add_class<C: Into<Cow<'static, str>>>(mut self, value: C) -> Self {
+    pub fn add_class<C: Into<Cow<'a, str>>>(mut self, value: C) -> Self {
         self.classes.insert(value.into());
         self
     }
@@ -63,7 +63,7 @@ impl Tag {
         }
     }
 
-    pub fn maybe_add_class<C: Into<Cow<'static, str>>>(self, value: Option<C>) -> Self {
+    pub fn maybe_add_class<C: Into<Cow<'a, str>>>(self, value: Option<C>) -> Self {
         if let Some(value) = value {
             self.add_class(value)
         } else {
@@ -71,7 +71,7 @@ impl Tag {
         }
     }
 
-    pub fn add_attribute<K: Into<Cow<'static, str>>, V: Into<Cow<'static, str>>>(
+    pub fn add_attribute<K: Into<Cow<'a, str>>, V: Into<Cow<'a, str>>>(
         mut self,
         name: K,
         value: V,
@@ -80,7 +80,7 @@ impl Tag {
         self
     }
 
-    pub fn maybe_add_attribute<K: Into<Cow<'static, str>>, V: Into<Cow<'static, str>>>(
+    pub fn maybe_add_attribute<K: Into<Cow<'a, str>>, V: Into<Cow<'a, str>>>(
         self,
         name: K,
         value: Option<V>,
@@ -92,7 +92,7 @@ impl Tag {
         }
     }
 
-    pub fn add_style<N: Into<Cow<'static, str>>, V: Into<Cow<'static, str>>>(
+    pub fn add_style<N: Into<Cow<'a, str>>, V: Into<Cow<'a, str>>>(
         mut self,
         name: N,
         value: V,
@@ -101,7 +101,7 @@ impl Tag {
         self
     }
 
-    pub fn maybe_add_style<N: Into<Cow<'static, str>>, V: Into<Cow<'static, str>>>(
+    pub fn maybe_add_style<N: Into<Cow<'a, str>>, V: Into<Cow<'a, str>>>(
         self,
         name: N,
         value: Option<V>,
@@ -114,7 +114,7 @@ impl Tag {
     }
 }
 
-impl Tag {
+impl<'a> Tag<'a> {
     fn render_opening(&self, b: &mut RenderBuffer) {
         b.push('<');
         b.push_str(&self.name);

--- a/packages/mrml-core/src/prelude/render/tag.rs
+++ b/packages/mrml-core/src/prelude/render/tag.rs
@@ -114,9 +114,9 @@ impl Tag {
     }
 
     fn opening(&self) -> String {
-        let mut res = String::new();
+        let mut res = super::RenderBuffer::default();
         self.render_opening(&mut res);
-        res
+        res.into()
     }
 
     fn render_opening(&self, b: &mut RenderBuffer) {
@@ -152,9 +152,9 @@ impl Tag {
     }
 
     pub fn open(&self) -> String {
-        let mut buffer = String::new();
-        self.render_open(&mut buffer);
-        buffer
+        let mut res = super::RenderBuffer::default();
+        self.render_open(&mut res);
+        res.into()
     }
 
     pub fn render_open(&self, b: &mut RenderBuffer) {
@@ -197,10 +197,10 @@ impl Tag {
     }
 
     pub fn render<T: AsRef<str>>(&self, input: T) -> String {
-        let mut buf = String::default();
+        let mut buf = super::RenderBuffer::default();
         self.render_open(&mut buf);
         buf.push_str(input.as_ref());
         self.render_close(&mut buf);
-        buf
+        buf.into()
     }
 }

--- a/packages/mrml-core/src/prelude/render/tag.rs
+++ b/packages/mrml-core/src/prelude/render/tag.rs
@@ -112,13 +112,9 @@ impl Tag {
             self
         }
     }
+}
 
-    fn opening(&self) -> String {
-        let mut res = super::RenderBuffer::default();
-        self.render_opening(&mut res);
-        res.into()
-    }
-
+impl Tag {
     fn render_opening(&self, b: &mut RenderBuffer) {
         b.push('<');
         b.push_str(&self.name);
@@ -151,29 +147,15 @@ impl Tag {
         }
     }
 
-    pub fn open(&self) -> String {
-        let mut res = super::RenderBuffer::default();
-        self.render_open(&mut res);
-        res.into()
-    }
-
     pub fn render_open(&self, b: &mut RenderBuffer) {
         self.render_opening(b);
         b.push('>');
-    }
-
-    pub fn close(&self) -> String {
-        format!("</{}>", self.name)
     }
 
     pub fn render_close(&self, b: &mut RenderBuffer) {
         b.push_str("</");
         b.push_str(self.name.as_ref());
         b.push('>');
-    }
-
-    pub fn closed(&self) -> String {
-        self.opening() + " />"
     }
 
     pub fn render_closed(&self, b: &mut RenderBuffer) {
@@ -194,13 +176,5 @@ impl Tag {
         self.render_open(buf);
         buf.push_str(value);
         self.render_close(buf);
-    }
-
-    pub fn render<T: AsRef<str>>(&self, input: T) -> String {
-        let mut buf = super::RenderBuffer::default();
-        self.render_open(&mut buf);
-        buf.push_str(input.as_ref());
-        self.render_close(&mut buf);
-        buf.into()
     }
 }

--- a/packages/mrml-core/src/root/parse.rs
+++ b/packages/mrml-core/src/root/parse.rs
@@ -61,26 +61,6 @@ impl crate::prelude::parser::AsyncParseChildren<Vec<RootChild>>
 impl super::Root {
     /// Function to parse a raw mjml template with some parsing
     /// [options](crate::prelude::parser::ParserOptions).
-    ///
-    /// You can specify the kind of loader mrml needs to use for loading the
-    /// content of [`mj-include`](crate::mj_include) elements.
-    ///
-    /// You can take a look at the available loaders
-    /// [here](crate::prelude::parser).
-    ///
-    /// ```rust
-    /// use mrml::root::Root;
-    /// use mrml::prelude::parser::ParserOptions;
-    /// use mrml::prelude::parser::memory_loader::MemoryIncludeLoader;
-    ///
-    /// let options = ParserOptions {
-    ///     include_loader: Box::new(MemoryIncludeLoader::default()),
-    /// };
-    /// match Root::parse_with_options("<mjml><mj-head /><mj-body /></mjml>", &options) {
-    ///     Ok(_) => println!("Success!"),
-    ///     Err(err) => eprintln!("Something went wrong: {err:?}"),
-    /// }
-    /// ```
     pub(crate) fn parse_with_options<T: AsRef<str>>(
         value: T,
         opts: &ParserOptions,

--- a/packages/mrml-core/src/root/render.rs
+++ b/packages/mrml-core/src/root/render.rs
@@ -1,12 +1,7 @@
 use crate::prelude::render::*;
 
-pub(crate) struct RootRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e super::Root,
-}
-
-impl<'e, 'h> Render<'e, 'h> for RootRender<'e, 'h> {
-    fn context(&self) -> &'h RenderContext<'h> {
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, super::Root, ()> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
@@ -23,9 +18,6 @@ impl<'e, 'h> Render<'e, 'h> for RootRender<'e, 'h> {
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for super::Root {
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(RootRender::<'e, 'h> {
-            element: self,
-            context,
-        })
+        Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/root/render.rs
+++ b/packages/mrml-core/src/root/render.rs
@@ -8,7 +8,7 @@ pub(crate) struct RootRender<'e, 'h> {
     element: &'e super::Root,
 }
 
-impl<'e, 'h> Render<'h> for RootRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for RootRender<'e, 'h> {
     fn header(&self) -> Ref<Header<'h>> {
         self.header.borrow()
     }
@@ -31,7 +31,7 @@ impl<'e, 'h> Render<'h> for RootRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for super::Root {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(RootRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/root/render.rs
+++ b/packages/mrml-core/src/root/render.rs
@@ -1,7 +1,7 @@
 use crate::prelude::render::*;
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, super::Root, ()> {
-    fn context(&self) -> &'header RenderContext<'header> {
+impl<'root> Render<'root> for Renderer<'root, super::Root, ()> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -16,8 +16,11 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for super::Root {
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for super::Root {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/root/render.rs
+++ b/packages/mrml-core/src/root/render.rs
@@ -1,28 +1,23 @@
 use crate::prelude::render::*;
 
 pub(crate) struct RootRender<'e, 'h> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e super::Root,
 }
 
 impl<'e, 'h> Render<'e, 'h> for RootRender<'e, 'h> {
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        self.context
     }
 
-    fn render(
-        &self,
-        opts: &RenderOptions,
-        header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
         for element in self.element.as_ref().iter() {
             match element {
                 super::RootChild::Comment(inner) => {
-                    inner.renderer(self.header).render(opts, header, buf)?
+                    inner.renderer(self.context).render(header, buf)?
                 }
                 super::RootChild::Mjml(inner) => {
-                    inner.renderer(self.header).render(opts, header, buf)?
+                    inner.renderer(self.context).render(header, buf)?
                 }
             };
         }
@@ -31,10 +26,10 @@ impl<'e, 'h> Render<'e, 'h> for RootRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for super::Root {
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(RootRender::<'e, 'h> {
             element: self,
-            header,
+            context,
         })
     }
 }

--- a/packages/mrml-core/src/root/render.rs
+++ b/packages/mrml-core/src/root/render.rs
@@ -1,7 +1,7 @@
 use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable};
 
 pub(crate) struct RootRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,
@@ -13,20 +13,18 @@ impl<'e, 'h> Render<'e, 'h> for RootRender<'e, 'h> {
         self.header.borrow()
     }
 
-    fn render(&self, opts: &RenderOptions) -> Result<String, Error> {
-        let mut result = String::new();
+    fn render(&self, opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
         for element in self.element.as_ref().iter() {
-            let content = match element {
+            match element {
                 super::RootChild::Comment(inner) => {
-                    inner.renderer(self.header.clone()).render(opts)?
+                    inner.renderer(self.header.clone()).render(opts, buf)?
                 }
                 super::RootChild::Mjml(inner) => {
-                    inner.renderer(self.header.clone()).render(opts)?
+                    inner.renderer(self.header.clone()).render(opts, buf)?
                 }
             };
-            result.push_str(&content);
         }
-        Ok(result)
+        Ok(())
     }
 }
 

--- a/packages/mrml-core/src/root/render.rs
+++ b/packages/mrml-core/src/root/render.rs
@@ -1,26 +1,28 @@
-use std::cell::{Ref, RefCell};
-use std::rc::Rc;
-
-use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable};
+use crate::prelude::render::*;
 
 pub(crate) struct RootRender<'e, 'h> {
-    header: Rc<RefCell<Header<'h>>>,
+    header: &'h Header<'h>,
     element: &'e super::Root,
 }
 
 impl<'e, 'h> Render<'e, 'h> for RootRender<'e, 'h> {
-    fn header(&self) -> Ref<Header<'h>> {
-        self.header.borrow()
+    fn header(&self) -> &'h Header<'h> {
+        self.header
     }
 
-    fn render(&self, opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(
+        &self,
+        opts: &RenderOptions,
+        header: &mut VariableHeader,
+        buf: &mut RenderBuffer,
+    ) -> Result<(), Error> {
         for element in self.element.as_ref().iter() {
             match element {
                 super::RootChild::Comment(inner) => {
-                    inner.renderer(self.header.clone()).render(opts, buf)?
+                    inner.renderer(self.header).render(opts, header, buf)?
                 }
                 super::RootChild::Mjml(inner) => {
-                    inner.renderer(self.header.clone()).render(opts, buf)?
+                    inner.renderer(self.header).render(opts, header, buf)?
                 }
             };
         }
@@ -29,7 +31,7 @@ impl<'e, 'h> Render<'e, 'h> for RootRender<'e, 'h> {
 }
 
 impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for super::Root {
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(RootRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/root/render.rs
+++ b/packages/mrml-core/src/root/render.rs
@@ -10,15 +10,11 @@ impl<'e, 'h> Render<'e, 'h> for RootRender<'e, 'h> {
         self.context
     }
 
-    fn render(&self, header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         for element in self.element.as_ref().iter() {
             match element {
-                super::RootChild::Comment(inner) => {
-                    inner.renderer(self.context).render(header, buf)?
-                }
-                super::RootChild::Mjml(inner) => {
-                    inner.renderer(self.context).render(header, buf)?
-                }
+                super::RootChild::Comment(inner) => inner.renderer(self.context).render(cursor)?,
+                super::RootChild::Mjml(inner) => inner.renderer(self.context).render(cursor)?,
             };
         }
         Ok(())

--- a/packages/mrml-core/src/text/render.rs
+++ b/packages/mrml-core/src/text/render.rs
@@ -1,13 +1,8 @@
 use super::Text;
 use crate::prelude::render::*;
 
-struct TextRender<'e, 'h> {
-    context: &'h RenderContext<'h>,
-    element: &'e Text,
-}
-
-impl<'e, 'h> Render<'e, 'h> for TextRender<'e, 'h> {
-    fn context(&self) -> &'h RenderContext<'h> {
+impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, Text, ()> {
+    fn context(&self) -> &'header RenderContext<'header> {
         self.context
     }
 
@@ -23,9 +18,6 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for Text {
     }
 
     fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
-        Box::new(TextRender::<'e, 'h> {
-            element: self,
-            context,
-        })
+        Box::new(Renderer::new(context, self, ()))
     }
 }

--- a/packages/mrml-core/src/text/render.rs
+++ b/packages/mrml-core/src/text/render.rs
@@ -1,20 +1,22 @@
-use std::cell::{Ref, RefCell};
-use std::rc::Rc;
-
 use super::Text;
-use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable};
+use crate::prelude::render::*;
 
 struct TextRender<'e, 'h> {
-    header: Rc<RefCell<Header<'h>>>,
+    header: &'h Header<'h>,
     element: &'e Text,
 }
 
 impl<'e, 'h> Render<'e, 'h> for TextRender<'e, 'h> {
-    fn header(&self) -> Ref<Header<'h>> {
-        self.header.borrow()
+    fn header(&self) -> &'h Header<'h> {
+        self.header
     }
 
-    fn render(&self, _opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
+    fn render(
+        &self,
+        _opts: &RenderOptions,
+        _header: &mut VariableHeader,
+        buf: &mut RenderBuffer,
+    ) -> Result<(), Error> {
         buf.push_str(self.element.inner_str());
         Ok(())
     }
@@ -25,7 +27,7 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for Text {
         true
     }
 
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(TextRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/text/render.rs
+++ b/packages/mrml-core/src/text/render.rs
@@ -2,7 +2,7 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use super::Text;
-use crate::prelude::render::{Error, Header, Render, RenderOptions, Renderable};
+use crate::prelude::render::{Error, Header, Render, RenderBuffer, RenderOptions, Renderable};
 
 struct TextRender<'e, 'h> {
     header: Rc<RefCell<Header<'h>>>,
@@ -14,8 +14,9 @@ impl<'e, 'h> Render<'e, 'h> for TextRender<'e, 'h> {
         self.header.borrow()
     }
 
-    fn render(&self, _opts: &RenderOptions) -> Result<String, Error> {
-        Ok(self.element.0.clone())
+    fn render(&self, _opts: &RenderOptions, buf: &mut RenderBuffer) -> Result<(), Error> {
+        buf.push_str(self.element.inner_str());
+        Ok(())
     }
 }
 

--- a/packages/mrml-core/src/text/render.rs
+++ b/packages/mrml-core/src/text/render.rs
@@ -9,7 +9,7 @@ struct TextRender<'e, 'h> {
     element: &'e Text,
 }
 
-impl<'e, 'h> Render<'h> for TextRender<'e, 'h> {
+impl<'e, 'h> Render<'e, 'h> for TextRender<'e, 'h> {
     fn header(&self) -> Ref<Header<'h>> {
         self.header.borrow()
     }
@@ -24,7 +24,7 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for Text {
         true
     }
 
-    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'h> + 'r> {
+    fn renderer(&'e self, header: Rc<RefCell<Header<'h>>>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(TextRender::<'e, 'h> {
             element: self,
             header,

--- a/packages/mrml-core/src/text/render.rs
+++ b/packages/mrml-core/src/text/render.rs
@@ -2,21 +2,16 @@ use super::Text;
 use crate::prelude::render::*;
 
 struct TextRender<'e, 'h> {
-    header: &'h Header<'h>,
+    context: &'h RenderContext<'h>,
     element: &'e Text,
 }
 
 impl<'e, 'h> Render<'e, 'h> for TextRender<'e, 'h> {
-    fn header(&self) -> &'h Header<'h> {
-        self.header
+    fn context(&self) -> &'h RenderContext<'h> {
+        self.context
     }
 
-    fn render(
-        &self,
-        _opts: &RenderOptions,
-        _header: &mut VariableHeader,
-        buf: &mut RenderBuffer,
-    ) -> Result<(), Error> {
+    fn render(&self, _header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
         buf.push_str(self.element.inner_str());
         Ok(())
     }
@@ -27,10 +22,10 @@ impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for Text {
         true
     }
 
-    fn renderer(&'e self, header: &'h Header<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
         Box::new(TextRender::<'e, 'h> {
             element: self,
-            header,
+            context,
         })
     }
 }

--- a/packages/mrml-core/src/text/render.rs
+++ b/packages/mrml-core/src/text/render.rs
@@ -11,8 +11,8 @@ impl<'e, 'h> Render<'e, 'h> for TextRender<'e, 'h> {
         self.context
     }
 
-    fn render(&self, _header: &mut VariableHeader, buf: &mut RenderBuffer) -> Result<(), Error> {
-        buf.push_str(self.element.inner_str());
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
+        cursor.buffer.push_str(self.element.inner_str());
         Ok(())
     }
 }

--- a/packages/mrml-core/src/text/render.rs
+++ b/packages/mrml-core/src/text/render.rs
@@ -1,8 +1,8 @@
 use super::Text;
 use crate::prelude::render::*;
 
-impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header, Text, ()> {
-    fn context(&self) -> &'header RenderContext<'header> {
+impl<'root> Render<'root> for Renderer<'root, Text, ()> {
+    fn context(&self) -> &'root RenderContext<'root> {
         self.context
     }
 
@@ -12,12 +12,15 @@ impl<'element, 'header> Render<'element, 'header> for Renderer<'element, 'header
     }
 }
 
-impl<'r, 'e: 'r, 'h: 'r> Renderable<'r, 'e, 'h> for Text {
-    fn is_raw(&'e self) -> bool {
+impl<'render, 'root: 'render> Renderable<'render, 'root> for Text {
+    fn is_raw(&'root self) -> bool {
         true
     }
 
-    fn renderer(&'e self, context: &'h RenderContext<'h>) -> Box<dyn Render<'e, 'h> + 'r> {
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
         Box::new(Renderer::new(context, self, ()))
     }
 }


### PR DESCRIPTION
- mrml-cli binary size: 6.3M -> 6.2M
- mrml perf improvement: 
```
     Running benches/basic.rs (/home/me/mrml/target/release/deps/basic-fad51e37a998db58)
render button           time:   [13.650 µs 13.704 µs 13.775 µs]
                        change: [-51.894% -50.927% -49.339%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

     Running benches/template.rs (/home/me/Personal/mrml/target/release/deps/template-1402eed9fef9d1c4)
amario                  time:   [478.81 µs 480.04 µs 481.41 µs]
                        change: [-51.877% -51.599% -51.291%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
```
