### PR TITLE
feat(mrml-core): add `Fragment` element

### DIFF
--- a/packages/mrml-core/Cargo.toml
+++ b/packages/mrml-core/Cargo.toml
@@ -18,6 +18,7 @@ travis-ci = { repository = "jdrouet/mrml", branch = "main" }
 [features]
 default = ["json", "parse", "print", "render"]
 json = ["dep:mrml-json-macros", "dep:serde", "dep:serde_json", "indexmap/serde"]
+fragment = []
 parse = ["dep:xmlparser", "dep:thiserror"]
 print = ["dep:enum_dispatch"]
 render = ["dep:enum-as-inner", "dep:thiserror"]

--- a/packages/mrml-core/resources/compare/success/fragment-column.html
+++ b/packages/mrml-core/resources/compare/success/fragment-column.html
@@ -1,0 +1,24 @@
+<!doctype html><html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head><title></title><!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]--><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<style type="text/css">
+#outlook a { padding: 0; }
+body { margin: 0; padding: 0; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+table, td { border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+img { border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; -ms-interpolation-mode: bicubic; }
+p { display: block; margin: 13px 0; }
+</style>
+<!--[if mso]>
+<noscript>
+<xml>
+<o:OfficeDocumentSettings>
+  <o:AllowPNG/>
+  <o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml>
+</noscript>
+<![endif]-->
+<!--[if lte mso 11]>
+<style type="text/css">
+.mj-outlook-group-fix { width:100% !important; }
+</style>
+<![endif]-->
+<!--[if !mso]><!--><link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css"><style type="text/css">@import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);</style><!--<![endif]--><style type="text/css">@media only screen and (min-width:480px) { .mj-column-per-100 { width:100% !important; max-width:100%; }  }</style><style media="screen and (min-width:480px)">.moz-text-html .mj-column-per-100 { width:100% !important; max-width:100%; } </style><style type="text/css"></style></head><body style="word-spacing:normal;"><div><div class="mj-outlook-group-fix mj-column-per-100" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%" style="vertical-align:top;"><tbody><tr><td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"><div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Hello World!Same child</div></td></tr><tr><td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"><div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Second child!</div></td></tr></tbody></table></div></div></body></html>

--- a/packages/mrml-core/src/fragment/json.rs
+++ b/packages/mrml-core/src/fragment/json.rs
@@ -1,0 +1,22 @@
+#[cfg(test)]
+mod tests {
+    use crate::fragment::Fragment;
+    use crate::text::Text;
+
+    #[test]
+    fn serialize() {
+        let mut elt = Fragment::<Text>::default();
+        elt.children.push(Text::from("Hello"));
+        assert_eq!(
+            serde_json::to_string(&elt).unwrap(),
+            r#"{"type":"fragment","children":["Hello"]}"#
+        );
+    }
+
+    #[test]
+    fn deserialize() {
+        let json = r#"{"type":"fragment","children":["Hello","World","!"]}"#;
+        let res: Fragment<Text> = serde_json::from_str(json).unwrap();
+        assert_eq!(res.children.len(), 3);
+    }
+}

--- a/packages/mrml-core/src/fragment/mod.rs
+++ b/packages/mrml-core/src/fragment/mod.rs
@@ -1,0 +1,31 @@
+#[cfg(feature = "json")]
+mod json;
+#[cfg(feature = "parse")]
+mod parse;
+#[cfg(feature = "print")]
+mod print;
+#[cfg(feature = "render")]
+mod render;
+
+pub const NAME: &str = "fragment";
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "json", derive(mrml_json_macros::MrmlJsonComponent))]
+#[cfg_attr(feature = "json", mrml_json(tag = "NAME"))]
+pub struct Fragment<T> {
+    pub children: Vec<T>,
+}
+
+impl<T> Default for Fragment<T> {
+    fn default() -> Self {
+        Self {
+            children: Default::default(),
+        }
+    }
+}
+
+impl<T> From<Vec<T>> for Fragment<T> {
+    fn from(children: Vec<T>) -> Self {
+        Self { children }
+    }
+}

--- a/packages/mrml-core/src/fragment/parse.rs
+++ b/packages/mrml-core/src/fragment/parse.rs
@@ -1,0 +1,43 @@
+use xmlparser::StrSpan;
+
+use super::Fragment;
+#[cfg(feature = "async")]
+use crate::prelude::parser::{AsyncMrmlParser, AsyncParseChildren, AsyncParseElement};
+use crate::prelude::parser::{Error, MrmlCursor, MrmlParser, ParseChildren, ParseElement};
+
+impl<'opts, T> ParseElement<Fragment<T>> for MrmlParser<'opts>
+where
+    MrmlParser<'opts>: ParseChildren<Vec<T>>,
+{
+    fn parse<'a>(
+        &self,
+        cursor: &mut MrmlCursor<'a>,
+        _tag: StrSpan<'a>,
+    ) -> Result<Fragment<T>, Error> {
+        let children = self.parse_children(cursor)?;
+
+        cursor.assert_element_close()?;
+
+        Ok(Fragment { children })
+    }
+}
+
+#[cfg(feature = "async")]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<T> AsyncParseElement<Fragment<T>> for AsyncMrmlParser
+where
+    AsyncMrmlParser: AsyncParseChildren<Vec<T>>,
+{
+    async fn async_parse<'a>(
+        &self,
+        cursor: &mut MrmlCursor<'a>,
+        _tag: StrSpan<'a>,
+    ) -> Result<Fragment<T>, Error> {
+        let children = self.async_parse_children(cursor).await?;
+
+        cursor.assert_element_close()?;
+
+        Ok(Fragment { children })
+    }
+}

--- a/packages/mrml-core/src/fragment/print.rs
+++ b/packages/mrml-core/src/fragment/print.rs
@@ -1,0 +1,20 @@
+use super::Fragment;
+use crate::prelude::print::{Printable, PrintableChildren, Printer};
+
+impl<T: Printable> Printable for Fragment<T> {
+    fn print<P: Printer>(&self, printer: &mut P) -> std::fmt::Result {
+        printer.push_indent();
+        printer.open_tag("")?;
+        printer.close_tag();
+        if !self.children.is_empty() {
+            printer.push_new_line();
+            printer.increase_indent();
+            self.children.print(printer)?;
+            printer.decrease_indent();
+            printer.push_indent();
+            printer.push_new_line();
+        }
+        printer.end_tag("")?;
+        Ok(())
+    }
+}

--- a/packages/mrml-core/src/fragment/render.rs
+++ b/packages/mrml-core/src/fragment/render.rs
@@ -69,7 +69,7 @@ mod tests {
     use crate::text::Text;
 
     #[test]
-    fn empty_script_should_have_closing_element() {
+    fn fragment_children_should_render() {
         use crate::mjml::Mjml;
         use crate::prelude::render::RenderOptions;
 
@@ -87,5 +87,47 @@ mod tests {
         let result = root.render(&opts).unwrap();
         assert!(result.contains("Hello World!"));
         assert!(result.contains("Second child!"));
+    }
+
+    #[test]
+    fn fragment_should_render_col_correctly() {
+        use crate::mj_column::MjColumn;
+        use crate::mj_text::MjText;
+        use crate::mjml::Mjml;
+        use crate::prelude::render::RenderOptions;
+
+        let opts = RenderOptions::default();
+        let mut root = Mjml::default();
+        let body = crate::mj_body::MjBody {
+            children: vec![MjColumn {
+                children: vec![Fragment::from(vec![
+                    MjText {
+                        children: vec![
+                            Text::from("Hello World!").into(),
+                            Text::from("Same child").into(),
+                        ],
+                        ..Default::default()
+                    }
+                    .into(),
+                    MjText {
+                        children: vec![Text::from("Second child!").into()],
+                        ..Default::default()
+                    }
+                    .into(),
+                ])
+                .into()],
+                ..Default::default()
+            }
+            .into()],
+            ..Default::default()
+        };
+        root.children.body = Some(body);
+        let result = root.render(&opts).unwrap();
+        let expected = include_str!(concat!(
+            "../../resources/compare/success/",
+            "fragment-column",
+            ".html"
+        ));
+        assert_eq!(result.as_str(), expected)
     }
 }

--- a/packages/mrml-core/src/fragment/render.rs
+++ b/packages/mrml-core/src/fragment/render.rs
@@ -18,9 +18,6 @@ where
     fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         for child in self.element.children.iter() {
             let mut renderer = child.renderer(self.context);
-            // renderer.set_index(index);
-            // renderer.set_raw_siblings(self.raw_siblings);
-            // renderer.set_siblings(self.siblings);
             renderer.set_container_width(self.container_width.clone());
             self.extra.iter().for_each(|(key, value)| {
                 renderer.add_extra_attribute(key, value);

--- a/packages/mrml-core/src/fragment/render.rs
+++ b/packages/mrml-core/src/fragment/render.rs
@@ -1,0 +1,94 @@
+use super::Fragment;
+use crate::prelude::hash::Map;
+use crate::prelude::render::*;
+
+impl<'render, 'root: 'render, T> Render<'root>
+    for Renderer<'root, Fragment<T>, Map<&'root str, &'root str>>
+where
+    T: Renderable<'render, 'root>,
+{
+    fn tag(&self) -> Option<&str> {
+        None
+    }
+
+    fn context(&self) -> &'root RenderContext<'root> {
+        self.context
+    }
+
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
+        for child in self.element.children.iter() {
+            let mut renderer = child.renderer(self.context);
+            // renderer.set_index(index);
+            // renderer.set_raw_siblings(self.raw_siblings);
+            // renderer.set_siblings(self.siblings);
+            renderer.set_container_width(self.container_width.clone());
+            self.extra.iter().for_each(|(key, value)| {
+                renderer.add_extra_attribute(key, value);
+            });
+            renderer.render(cursor)?;
+        }
+        Ok(())
+    }
+
+    fn set_container_width(&mut self, width: Option<crate::helper::size::Pixel>) {
+        self.container_width = width;
+    }
+
+    fn set_index(&mut self, index: usize) {
+        self.index = index;
+    }
+
+    fn set_siblings(&mut self, count: usize) {
+        self.siblings = count;
+    }
+
+    fn set_raw_siblings(&mut self, count: usize) {
+        self.raw_siblings = count
+    }
+
+    fn add_extra_attribute(&mut self, key: &'root str, value: &'root str) {
+        self.extra.insert(key, value);
+    }
+
+    fn raw_extra_attribute(&self, key: &str) -> Option<&'root str> {
+        self.extra.get(key).copied()
+    }
+}
+
+impl<'render, 'root: 'render, T: Renderable<'render, 'root>> Renderable<'render, 'root>
+    for Fragment<T>
+{
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
+        Box::new(Renderer::new(context, self, Map::new()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::fragment::Fragment;
+    use crate::text::Text;
+
+    #[test]
+    fn empty_script_should_have_closing_element() {
+        use crate::mjml::Mjml;
+        use crate::prelude::render::RenderOptions;
+
+        let opts = RenderOptions::default();
+        let mut root = Mjml::default();
+        let body = crate::mj_body::MjBody {
+            children: vec![Fragment::from(vec![
+                Text::from("Hello World!").into(),
+                Text::from("Second child!").into(),
+            ])
+            .into()],
+            ..Default::default()
+        };
+        root.children.body = Some(body);
+        let result = root.render(&opts).unwrap();
+        assert!(result.contains("Hello World!"));
+        assert!(result.contains("Second child!"));
+    }
+}

--- a/packages/mrml-core/src/lib.rs
+++ b/packages/mrml-core/src/lib.rs
@@ -165,6 +165,7 @@ pub mod text;
 // Only used to ignore the comments at the root level
 mod root;
 
+#[cfg(feature = "fragment")]
 pub mod fragment;
 mod helper;
 

--- a/packages/mrml-core/src/lib.rs
+++ b/packages/mrml-core/src/lib.rs
@@ -165,6 +165,7 @@ pub mod text;
 // Only used to ignore the comments at the root level
 mod root;
 
+pub mod fragment;
 mod helper;
 
 #[cfg(feature = "parse")]

--- a/packages/mrml-core/src/mj_accordion/children.rs
+++ b/packages/mrml-core/src/mj_accordion/children.rs
@@ -1,4 +1,5 @@
 use crate::comment::Comment;
+#[cfg(feature = "fragment")]
 use crate::fragment::Fragment;
 use crate::mj_accordion_element::MjAccordionElement;
 
@@ -8,6 +9,7 @@ use crate::mj_accordion_element::MjAccordionElement;
 #[cfg_attr(feature = "print", enum_dispatch::enum_dispatch)]
 pub enum MjAccordionChild {
     Comment(Comment),
+    #[cfg(feature = "fragment")]
     Fragment(Fragment<Self>),
     MjAccordionElement(MjAccordionElement),
 }

--- a/packages/mrml-core/src/mj_accordion/children.rs
+++ b/packages/mrml-core/src/mj_accordion/children.rs
@@ -1,4 +1,5 @@
 use crate::comment::Comment;
+use crate::fragment::Fragment;
 use crate::mj_accordion_element::MjAccordionElement;
 
 #[derive(Debug)]
@@ -7,5 +8,6 @@ use crate::mj_accordion_element::MjAccordionElement;
 #[cfg_attr(feature = "print", enum_dispatch::enum_dispatch)]
 pub enum MjAccordionChild {
     Comment(Comment),
+    Fragment(Fragment<Self>),
     MjAccordionElement(MjAccordionElement),
 }

--- a/packages/mrml-core/src/mj_accordion/render.rs
+++ b/packages/mrml-core/src/mj_accordion/render.rs
@@ -32,6 +32,7 @@ const STYLE: &str = r#"noinput.mj-accordion-checkbox { display: block! important
 "#;
 
 impl<'root> Renderer<'root, MjAccordion, ()> {
+    #[cfg(feature = "fragment")]
     fn children_iter(&self) -> impl Iterator<Item = &MjAccordionChild> {
         fn folder<'root>(
             c: &'root MjAccordionChild,
@@ -42,6 +43,11 @@ impl<'root> Renderer<'root, MjAccordion, ()> {
             }
         }
         self.element.children.iter().flat_map(folder)
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children_iter(&self) -> impl Iterator<Item = &MjAccordionChild> {
+        self.element.children.iter()
     }
 
     fn update_header(&self, header: &mut VariableHeader) {
@@ -151,6 +157,7 @@ impl<'render, 'root: 'render> Renderable<'render, 'root> for MjAccordionChild {
     ) -> Box<dyn Render<'root> + 'render> {
         match self {
             Self::MjAccordionElement(elt) => elt.renderer(context),
+            #[cfg(feature = "fragment")]
             Self::Fragment(elt) => elt.renderer(context),
             Self::Comment(elt) => elt.renderer(context),
         }

--- a/packages/mrml-core/src/mj_attributes/parse.rs
+++ b/packages/mrml-core/src/mj_attributes/parse.rs
@@ -18,6 +18,7 @@ impl<'opts> ParseElement<MjAttributesChild> for MrmlParser<'opts> {
         Ok(match tag.as_str() {
             MJ_ALL => MjAttributesChild::MjAttributesAll(self.parse(cursor, tag)?),
             MJ_CLASS => MjAttributesChild::MjAttributesClass(self.parse(cursor, tag)?),
+            // _ if tag.is_empty() => Ok(MjAttributesChild::Fragment(self.parse(cursor, tag)?)),
             _ => MjAttributesChild::MjAttributesElement(self.parse(cursor, tag)?),
         })
     }
@@ -35,6 +36,8 @@ impl AsyncParseElement<MjAttributesChild> for AsyncMrmlParser {
         Ok(match tag.as_str() {
             MJ_ALL => MjAttributesChild::MjAttributesAll(self.async_parse(cursor, tag).await?),
             MJ_CLASS => MjAttributesChild::MjAttributesClass(self.async_parse(cursor, tag).await?),
+            // _ if tag.is_empty() => Ok(MjAttributesChild::Fragment(self.async_parse(cursor,
+            // tag)?)),
             _ => MjAttributesChild::MjAttributesElement(self.async_parse(cursor, tag).await?),
         })
     }

--- a/packages/mrml-core/src/mj_body/children.rs
+++ b/packages/mrml-core/src/mj_body/children.rs
@@ -1,4 +1,5 @@
 use crate::comment::Comment;
+#[cfg(feature = "fragment")]
 use crate::fragment::Fragment;
 use crate::mj_accordion::MjAccordion;
 use crate::mj_button::MjButton;
@@ -28,6 +29,7 @@ use crate::text::Text;
 #[cfg_attr(feature = "print", enum_dispatch::enum_dispatch)]
 pub enum MjBodyChild {
     Comment(Comment),
+    #[cfg(feature = "fragment")]
     Fragment(Fragment<Self>),
     MjAccordion(MjAccordion),
     MjButton(MjButton),
@@ -55,6 +57,7 @@ impl<'render, 'root: 'render> Renderable<'render, 'root> for MjBodyChild {
     fn is_raw(&self) -> bool {
         match self {
             Self::Comment(elt) => elt.is_raw(),
+            #[cfg(feature = "fragment")]
             Self::Fragment(elt) => elt.is_raw(),
             Self::MjAccordion(elt) => elt.is_raw(),
             Self::MjButton(elt) => elt.is_raw(),
@@ -84,6 +87,7 @@ impl<'render, 'root: 'render> Renderable<'render, 'root> for MjBodyChild {
     ) -> Box<dyn Render<'root> + 'render> {
         match self {
             Self::Comment(elt) => elt.renderer(context),
+            #[cfg(feature = "fragment")]
             Self::Fragment(elt) => elt.renderer(context),
             Self::MjAccordion(elt) => elt.renderer(context),
             Self::MjButton(elt) => elt.renderer(context),

--- a/packages/mrml-core/src/mj_body/children.rs
+++ b/packages/mrml-core/src/mj_body/children.rs
@@ -1,4 +1,5 @@
 use crate::comment::Comment;
+use crate::fragment::Fragment;
 use crate::mj_accordion::MjAccordion;
 use crate::mj_button::MjButton;
 use crate::mj_carousel::MjCarousel;
@@ -27,6 +28,7 @@ use crate::text::Text;
 #[cfg_attr(feature = "print", enum_dispatch::enum_dispatch)]
 pub enum MjBodyChild {
     Comment(Comment),
+    Fragment(Fragment<Self>),
     MjAccordion(MjAccordion),
     MjButton(MjButton),
     MjCarousel(MjCarousel),
@@ -53,6 +55,7 @@ impl<'render, 'root: 'render> Renderable<'render, 'root> for MjBodyChild {
     fn is_raw(&self) -> bool {
         match self {
             Self::Comment(elt) => elt.is_raw(),
+            Self::Fragment(elt) => elt.is_raw(),
             Self::MjAccordion(elt) => elt.is_raw(),
             Self::MjButton(elt) => elt.is_raw(),
             Self::MjCarousel(elt) => elt.is_raw(),
@@ -81,6 +84,7 @@ impl<'render, 'root: 'render> Renderable<'render, 'root> for MjBodyChild {
     ) -> Box<dyn Render<'root> + 'render> {
         match self {
             Self::Comment(elt) => elt.renderer(context),
+            Self::Fragment(elt) => elt.renderer(context),
             Self::MjAccordion(elt) => elt.renderer(context),
             Self::MjButton(elt) => elt.renderer(context),
             Self::MjCarousel(elt) => elt.renderer(context),

--- a/packages/mrml-core/src/mj_body/parse.rs
+++ b/packages/mrml-core/src/mj_body/parse.rs
@@ -2,6 +2,7 @@ use xmlparser::StrSpan;
 
 use super::{MjBody, MjBodyChild};
 use crate::comment::Comment;
+
 use crate::mj_accordion::NAME as MJ_ACCORDION;
 use crate::mj_button::NAME as MJ_BUTTON;
 use crate::mj_carousel::NAME as MJ_CAROUSEL;
@@ -111,6 +112,7 @@ impl<'opts> ParseElement<MjBodyChild> for MrmlParser<'opts> {
             MJ_TABLE => Ok(MjBodyChild::MjTable(self.parse(cursor, tag)?)),
             MJ_TEXT => Ok(MjBodyChild::MjText(self.parse(cursor, tag)?)),
             MJ_WRAPPER => Ok(MjBodyChild::MjWrapper(self.parse(cursor, tag)?)),
+            _ if tag.is_empty() => Ok(MjBodyChild::Fragment(self.parse(cursor, tag)?)),
             _ => Ok(MjBodyChild::Node(self.parse(cursor, tag)?)),
         }
     }
@@ -147,6 +149,7 @@ impl AsyncParseElement<MjBodyChild> for AsyncMrmlParser {
             MJ_TABLE => Ok(MjBodyChild::MjTable(self.async_parse(cursor, tag).await?)),
             MJ_TEXT => Ok(MjBodyChild::MjText(self.async_parse(cursor, tag).await?)),
             MJ_WRAPPER => Ok(MjBodyChild::MjWrapper(self.async_parse(cursor, tag).await?)),
+            _ if tag.is_empty() => Ok(MjBodyChild::Fragment(self.async_parse(cursor, tag).await?)),
             _ => Ok(MjBodyChild::Node(self.async_parse(cursor, tag).await?)),
         }
     }

--- a/packages/mrml-core/src/mj_body/parse.rs
+++ b/packages/mrml-core/src/mj_body/parse.rs
@@ -112,6 +112,7 @@ impl<'opts> ParseElement<MjBodyChild> for MrmlParser<'opts> {
             MJ_TABLE => Ok(MjBodyChild::MjTable(self.parse(cursor, tag)?)),
             MJ_TEXT => Ok(MjBodyChild::MjText(self.parse(cursor, tag)?)),
             MJ_WRAPPER => Ok(MjBodyChild::MjWrapper(self.parse(cursor, tag)?)),
+            #[cfg(feature = "fragment")]
             _ if tag.is_empty() => Ok(MjBodyChild::Fragment(self.parse(cursor, tag)?)),
             _ => Ok(MjBodyChild::Node(self.parse(cursor, tag)?)),
         }
@@ -149,6 +150,7 @@ impl AsyncParseElement<MjBodyChild> for AsyncMrmlParser {
             MJ_TABLE => Ok(MjBodyChild::MjTable(self.async_parse(cursor, tag).await?)),
             MJ_TEXT => Ok(MjBodyChild::MjText(self.async_parse(cursor, tag).await?)),
             MJ_WRAPPER => Ok(MjBodyChild::MjWrapper(self.async_parse(cursor, tag).await?)),
+            #[cfg(feature = "fragment")]
             _ if tag.is_empty() => Ok(MjBodyChild::Fragment(self.async_parse(cursor, tag).await?)),
             _ => Ok(MjBodyChild::Node(self.async_parse(cursor, tag).await?)),
         }

--- a/packages/mrml-core/src/mj_body/render.rs
+++ b/packages/mrml-core/src/mj_body/render.rs
@@ -21,6 +21,16 @@ impl<'root> Renderer<'root, MjBody, ()> {
         self.element.children.iter()
     }
 
+    #[cfg(feature = "fragment")]
+    fn children_count(&self) -> usize {
+        self.children_iter().count()
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children_count(&self) -> usize {
+        self.element.children.len()
+    }
+
     fn get_width(&self) -> Option<Pixel> {
         self.attribute("width")
             .and_then(|value| Pixel::try_from(value).ok())
@@ -57,7 +67,7 @@ impl<'root> Renderer<'root, MjBody, ()> {
         let element_width = self.get_width();
 
         div.render_open(&mut cursor.buffer)?;
-        let siblings = self.children_iter().count();
+        let siblings = self.children_count();
         let raw_siblings = self.children_iter().filter(|i| i.is_raw()).count();
 
         for (index, child) in self.children_iter().enumerate() {

--- a/packages/mrml-core/src/mj_body/render.rs
+++ b/packages/mrml-core/src/mj_body/render.rs
@@ -5,6 +5,7 @@ use crate::helper::size::Pixel;
 use crate::prelude::render::*;
 
 impl<'root> Renderer<'root, MjBody, ()> {
+    #[cfg(feature = "fragment")]
     fn children_iter(&self) -> impl Iterator<Item = &MjBodyChild> {
         fn folder<'root>(c: &'root MjBodyChild) -> Box<dyn Iterator<Item = &MjBodyChild> + 'root> {
             match c {
@@ -13,6 +14,11 @@ impl<'root> Renderer<'root, MjBody, ()> {
             }
         }
         self.element.children.iter().flat_map(folder)
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children_iter(&self) -> impl Iterator<Item = &MjBodyChild> {
+        self.element.children.iter()
     }
 
     fn get_width(&self) -> Option<Pixel> {

--- a/packages/mrml-core/src/mj_carousel/children.rs
+++ b/packages/mrml-core/src/mj_carousel/children.rs
@@ -1,4 +1,5 @@
 use crate::comment::Comment;
+#[cfg(feature = "fragment")]
 use crate::fragment::Fragment;
 use crate::mj_carousel_image::MjCarouselImage;
 
@@ -8,6 +9,7 @@ use crate::mj_carousel_image::MjCarouselImage;
 #[cfg_attr(feature = "print", enum_dispatch::enum_dispatch)]
 pub enum MjCarouselChild {
     Comment(Comment),
+    #[cfg(feature = "fragment")]
     Fragment(Fragment<Self>),
     MjCarouselImage(MjCarouselImage),
 }

--- a/packages/mrml-core/src/mj_carousel/children.rs
+++ b/packages/mrml-core/src/mj_carousel/children.rs
@@ -1,4 +1,5 @@
 use crate::comment::Comment;
+use crate::fragment::Fragment;
 use crate::mj_carousel_image::MjCarouselImage;
 
 #[derive(Debug)]
@@ -7,6 +8,7 @@ use crate::mj_carousel_image::MjCarouselImage;
 #[cfg_attr(feature = "print", enum_dispatch::enum_dispatch)]
 pub enum MjCarouselChild {
     Comment(Comment),
+    Fragment(Fragment<Self>),
     MjCarouselImage(MjCarouselImage),
 }
 

--- a/packages/mrml-core/src/mj_carousel/print.rs
+++ b/packages/mrml-core/src/mj_carousel/print.rs
@@ -16,9 +16,9 @@ impl PrintableElement for super::MjCarousel {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        mj_carousel::MjCarousel, mj_carousel_image::MjCarouselImage, prelude::print::Printable,
-    };
+    use crate::mj_carousel::MjCarousel;
+    use crate::mj_carousel_image::MjCarouselImage;
+    use crate::prelude::print::Printable;
 
     #[test]
     fn empty() {

--- a/packages/mrml-core/src/mj_carousel/render.rs
+++ b/packages/mrml-core/src/mj_carousel/render.rs
@@ -44,8 +44,19 @@ impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
     fn children_iter(&self) -> impl Iterator<Item = &MjCarouselChild> {
         self.element.children.iter()
     }
+
+    #[cfg(feature = "fragment")]
+    fn children_count(&self) -> usize {
+        self.children_iter().count()
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children_count(&self) -> usize {
+        self.element.children.len()
+    }
+
     fn get_thumbnails_width(&self) -> Pixel {
-        let count = self.children_iter().count();
+        let count = self.children_count();
         if count == 0 {
             Pixel::new(0.0)
         } else {
@@ -266,7 +277,7 @@ impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
     }
 
     fn render_style(&self) -> Option<String> {
-        let length = self.children_iter().count();
+        let length = self.children_count();
         if length == 0 {
             return None;
         }

--- a/packages/mrml-core/src/mj_carousel/render.rs
+++ b/packages/mrml-core/src/mj_carousel/render.rs
@@ -10,6 +10,7 @@ impl<'render, 'root: 'render> Renderable<'render, 'root> for MjCarouselChild {
     ) -> Box<dyn Render<'root> + 'render> {
         match self {
             Self::MjCarouselImage(elt) => elt.renderer(context),
+            #[cfg(feature = "fragment")]
             Self::Fragment(elt) => elt.renderer(context),
             Self::Comment(elt) => elt.renderer(context),
         }
@@ -25,6 +26,8 @@ struct MjCarouselExtra {
 }
 
 impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
+    #[cfg(feature = "fragment")]
+
     fn children_iter(&self) -> impl Iterator<Item = &MjCarouselChild> {
         fn folder<'root>(
             c: &'root MjCarouselChild,
@@ -37,6 +40,10 @@ impl<'root> Renderer<'root, MjCarousel, MjCarouselExtra> {
         self.element.children.iter().flat_map(folder)
     }
 
+    #[cfg(not(feature = "fragment"))]
+    fn children_iter(&self) -> impl Iterator<Item = &MjCarouselChild> {
+        self.element.children.iter()
+    }
     fn get_thumbnails_width(&self) -> Pixel {
         let count = self.children_iter().count();
         if count == 0 {

--- a/packages/mrml-core/src/mj_column/render.rs
+++ b/packages/mrml-core/src/mj_column/render.rs
@@ -25,6 +25,16 @@ impl<'root> Renderer<'root, MjColumn, MjColumnExtra<'root>> {
         self.element.children.iter()
     }
 
+    #[cfg(feature = "fragment")]
+    fn children_count(&self) -> usize {
+        self.children_iter().count()
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children_count(&self) -> usize {
+        self.element.children.len()
+    }
+
     fn current_width(&self) -> Option<Pixel> {
         let parent_width = self.container_width.as_ref()?;
         let non_raw_siblings = self.non_raw_siblings();
@@ -242,7 +252,7 @@ impl<'root> Renderer<'root, MjColumn, MjColumnExtra<'root>> {
             .add_attribute("width", "100%");
         let tbody = Tag::tbody();
 
-        let siblings = self.children_iter().count();
+        let siblings = self.children_count();
         let raw_siblings = self.children_iter().filter(|i| i.is_raw()).count();
 
         let current_width = self.current_width();

--- a/packages/mrml-core/src/mj_column/render.rs
+++ b/packages/mrml-core/src/mj_column/render.rs
@@ -9,6 +9,7 @@ struct MjColumnExtra<'a> {
 }
 
 impl<'root> Renderer<'root, MjColumn, MjColumnExtra<'root>> {
+    #[cfg(feature = "fragment")]
     fn children_iter(&self) -> impl Iterator<Item = &MjBodyChild> {
         fn folder<'root>(c: &'root MjBodyChild) -> Box<dyn Iterator<Item = &MjBodyChild> + 'root> {
             match c {
@@ -18,6 +19,12 @@ impl<'root> Renderer<'root, MjColumn, MjColumnExtra<'root>> {
         }
         self.element.children.iter().flat_map(folder)
     }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children_iter(&self) -> impl Iterator<Item = &MjBodyChild> {
+        self.element.children.iter()
+    }
+
     fn current_width(&self) -> Option<Pixel> {
         let parent_width = self.container_width.as_ref()?;
         let non_raw_siblings = self.non_raw_siblings();

--- a/packages/mrml-core/src/mj_group/render.rs
+++ b/packages/mrml-core/src/mj_group/render.rs
@@ -6,6 +6,7 @@ use crate::mj_body::MjBodyChild;
 use crate::prelude::render::*;
 
 impl<'root> Renderer<'root, MjGroup, ()> {
+    #[cfg(feature = "fragment")]
     fn children_iter(&self) -> impl Iterator<Item = &MjBodyChild> {
         fn folder<'root>(c: &'root MjBodyChild) -> Box<dyn Iterator<Item = &MjBodyChild> + 'root> {
             match c {
@@ -14,6 +15,11 @@ impl<'root> Renderer<'root, MjGroup, ()> {
             }
         }
         self.element.children.iter().flat_map(folder)
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children_iter(&self) -> impl Iterator<Item = &MjBodyChild> {
+        self.element.children.iter()
     }
 
     fn current_width(&self) -> Pixel {

--- a/packages/mrml-core/src/mj_group/render.rs
+++ b/packages/mrml-core/src/mj_group/render.rs
@@ -22,6 +22,16 @@ impl<'root> Renderer<'root, MjGroup, ()> {
         self.element.children.iter()
     }
 
+    #[cfg(feature = "fragment")]
+    fn children_count(&self) -> usize {
+        self.children_iter().count()
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children_count(&self) -> usize {
+        self.element.children.len()
+    }
+
     fn current_width(&self) -> Pixel {
         let parent_width = self.container_width.as_ref().unwrap();
         let non_raw_siblings = self.non_raw_siblings();
@@ -93,7 +103,7 @@ impl<'root> Renderer<'root, MjGroup, ()> {
 
     fn render_children(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let current_width = self.current_width();
-        let siblings = self.children_iter().count();
+        let siblings = self.children_count();
         let raw_siblings = self.children_iter().filter(|item| item.is_raw()).count();
 
         for (index, child) in self.children_iter().enumerate() {

--- a/packages/mrml-core/src/mj_head/children.rs
+++ b/packages/mrml-core/src/mj_head/children.rs
@@ -1,4 +1,5 @@
 use crate::comment::Comment;
+use crate::fragment::Fragment;
 use crate::mj_attributes::MjAttributes;
 use crate::mj_breakpoint::MjBreakpoint;
 use crate::mj_font::MjFont;
@@ -15,6 +16,7 @@ use crate::mj_title::MjTitle;
 #[cfg_attr(feature = "render", derive(enum_as_inner::EnumAsInner))]
 pub enum MjHeadChild {
     Comment(Comment),
+    Fragment(Fragment<Self>),
     MjAttributes(MjAttributes),
     MjBreakpoint(MjBreakpoint),
     MjFont(MjFont),

--- a/packages/mrml-core/src/mj_head/children.rs
+++ b/packages/mrml-core/src/mj_head/children.rs
@@ -1,4 +1,5 @@
 use crate::comment::Comment;
+#[cfg(feature = "fragment")]
 use crate::fragment::Fragment;
 use crate::mj_attributes::MjAttributes;
 use crate::mj_breakpoint::MjBreakpoint;
@@ -16,6 +17,7 @@ use crate::mj_title::MjTitle;
 #[cfg_attr(feature = "render", derive(enum_as_inner::EnumAsInner))]
 pub enum MjHeadChild {
     Comment(Comment),
+    #[cfg(feature = "fragment")]
     Fragment(Fragment<Self>),
     MjAttributes(MjAttributes),
     MjBreakpoint(MjBreakpoint),

--- a/packages/mrml-core/src/mj_head/mod.rs
+++ b/packages/mrml-core/src/mj_head/mod.rs
@@ -78,6 +78,7 @@ impl MjHead {
             .last()
     }
 
+    #[cfg(feature = "fragment")]
     pub fn children(&self) -> Vec<&MjHeadChild> {
         fn folder<'root>(
             mut acc: Vec<&'root MjHeadChild>,
@@ -92,5 +93,10 @@ impl MjHead {
             acc
         }
         self.children.iter().fold(Vec::new(), folder)
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    pub fn children(&self) -> Vec<&MjHeadChild> {
+        self.children.iter().collect()
     }
 }

--- a/packages/mrml-core/src/mj_head/mod.rs
+++ b/packages/mrml-core/src/mj_head/mod.rs
@@ -22,7 +22,7 @@ pub struct MjHead {
 #[cfg(feature = "render")]
 impl MjHead {
     pub fn breakpoint(&self) -> Option<&crate::mj_breakpoint::MjBreakpoint> {
-        self.children
+        self.children()
             .iter()
             .flat_map(|item| {
                 item.as_mj_breakpoint().into_iter().chain(
@@ -41,7 +41,7 @@ impl MjHead {
     }
 
     pub fn preview(&self) -> Option<&crate::mj_preview::MjPreview> {
-        self.children
+        self.children()
             .iter()
             .flat_map(|item| {
                 item.as_mj_preview().into_iter().chain(
@@ -60,7 +60,7 @@ impl MjHead {
     }
 
     pub fn title(&self) -> Option<&crate::mj_title::MjTitle> {
-        self.children
+        self.children()
             .iter()
             .flat_map(|item| {
                 item.as_mj_title().into_iter().chain(
@@ -78,7 +78,19 @@ impl MjHead {
             .last()
     }
 
-    pub fn children(&self) -> &Vec<MjHeadChild> {
-        &self.children
+    pub fn children(&self) -> Vec<&MjHeadChild> {
+        fn folder<'root>(
+            mut acc: Vec<&'root MjHeadChild>,
+            c: &'root MjHeadChild,
+        ) -> Vec<&'root MjHeadChild> {
+            match c {
+                MjHeadChild::Fragment(f) => {
+                    acc.append(&mut f.children.iter().fold(Vec::new(), folder))
+                }
+                _ => acc.push(c),
+            }
+            acc
+        }
+        self.children.iter().fold(Vec::new(), folder)
     }
 }

--- a/packages/mrml-core/src/mj_head/parse.rs
+++ b/packages/mrml-core/src/mj_head/parse.rs
@@ -1,6 +1,8 @@
 use xmlparser::StrSpan;
 
 use super::{MjHead, MjHeadChild};
+use crate::comment::Comment;
+use crate::mj_attributes::NAME as MJ_ATTRIBUTES;
 use crate::mj_breakpoint::NAME as MJ_BREAKPOINT;
 use crate::mj_font::NAME as MJ_FONT;
 use crate::mj_include::NAME as MJ_INCLUDE;
@@ -13,7 +15,6 @@ use crate::prelude::parser::{AsyncMrmlParser, AsyncParseChildren, AsyncParseElem
 use crate::prelude::parser::{
     Error, MrmlCursor, MrmlParser, MrmlToken, ParseChildren, ParseElement,
 };
-use crate::{comment::Comment, mj_attributes::NAME as MJ_ATTRIBUTES};
 
 impl<'opts> ParseChildren<Vec<MjHeadChild>> for MrmlParser<'opts> {
     fn parse_children(&self, cursor: &mut MrmlCursor<'_>) -> Result<Vec<MjHeadChild>, Error> {
@@ -117,6 +118,7 @@ impl<'opts> ParseElement<MjHeadChild> for MrmlParser<'opts> {
             MJ_RAW => self.parse(cursor, tag).map(MjHeadChild::MjRaw),
             MJ_STYLE => self.parse(cursor, tag).map(MjHeadChild::MjStyle),
             MJ_TITLE => self.parse(cursor, tag).map(MjHeadChild::MjTitle),
+            _ if tag.is_empty() => Ok(MjHeadChild::Fragment(self.parse(cursor, tag)?)),
             _ => Err(Error::UnexpectedElement(tag.into())),
         }
     }
@@ -158,6 +160,8 @@ impl AsyncParseElement<MjHeadChild> for AsyncMrmlParser {
                 .async_parse(cursor, tag)
                 .await
                 .map(MjHeadChild::MjTitle),
+
+            _ if tag.is_empty() => Ok(MjHeadChild::Fragment(self.async_parse(cursor, tag).await?)),
             _ => Err(Error::UnexpectedElement(tag.into())),
         }
     }

--- a/packages/mrml-core/src/mj_head/parse.rs
+++ b/packages/mrml-core/src/mj_head/parse.rs
@@ -118,6 +118,7 @@ impl<'opts> ParseElement<MjHeadChild> for MrmlParser<'opts> {
             MJ_RAW => self.parse(cursor, tag).map(MjHeadChild::MjRaw),
             MJ_STYLE => self.parse(cursor, tag).map(MjHeadChild::MjStyle),
             MJ_TITLE => self.parse(cursor, tag).map(MjHeadChild::MjTitle),
+            #[cfg(feature = "fragment")]
             _ if tag.is_empty() => Ok(MjHeadChild::Fragment(self.parse(cursor, tag)?)),
             _ => Err(Error::UnexpectedElement(tag.into())),
         }
@@ -161,6 +162,7 @@ impl AsyncParseElement<MjHeadChild> for AsyncMrmlParser {
                 .await
                 .map(MjHeadChild::MjTitle),
 
+            #[cfg(feature = "fragment")]
             _ if tag.is_empty() => Ok(MjHeadChild::Fragment(self.async_parse(cursor, tag).await?)),
             _ => Err(Error::UnexpectedElement(tag.into())),
         }

--- a/packages/mrml-core/src/mj_head/render.rs
+++ b/packages/mrml-core/src/mj_head/render.rs
@@ -39,7 +39,7 @@ fn combine_attribute_map<'a>(
 
 impl MjHead {
     pub fn build_attributes_all(&self) -> Map<&str, &str> {
-        self.children
+        self.children()
             .iter()
             .flat_map(|item| {
                 item.as_mj_attributes()
@@ -56,7 +56,7 @@ impl MjHead {
     }
 
     pub fn build_attributes_class(&self) -> Map<&str, Map<&str, &str>> {
-        self.children
+        self.children()
             .iter()
             .flat_map(|item| {
                 item.as_mj_attributes()
@@ -73,7 +73,7 @@ impl MjHead {
     }
 
     pub fn build_attributes_element(&self) -> Map<&str, Map<&str, &str>> {
-        self.children
+        self.children()
             .iter()
             .flat_map(|item| {
                 item.as_mj_attributes()
@@ -90,7 +90,7 @@ impl MjHead {
     }
 
     pub fn build_font_families(&self) -> Map<&str, &str> {
-        self.children
+        self.children()
             .iter()
             .flat_map(|item| {
                 item.as_mj_font().into_iter().chain(
@@ -118,7 +118,7 @@ fn render_font_link(target: &mut String, href: &str) {
 
 impl<'root> Renderer<'root, MjHead, ()> {
     fn mj_style_iter(&self) -> impl Iterator<Item = &str> {
-        self.element.children.iter().flat_map(|item| {
+        self.element.children().into_iter().flat_map(|item| {
             item.as_mj_include()
                 .into_iter()
                 .flat_map(|inner| {
@@ -241,8 +241,11 @@ impl<'root> Renderer<'root, MjHead, ()> {
 
     fn render_raw(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let mut index: usize = 0;
-        let siblings = self.element.children.len();
-        for child in self.element.children.iter() {
+
+        let children = self.element.children();
+        let siblings = children.len();
+
+        for child in children.into_iter() {
             if let Some(mj_raw) = child.as_mj_raw() {
                 let mut renderer = mj_raw.renderer(self.context());
                 renderer.set_index(index);

--- a/packages/mrml-core/src/mj_hero/render.rs
+++ b/packages/mrml-core/src/mj_hero/render.rs
@@ -6,6 +6,7 @@ use crate::mj_body::MjBodyChild;
 use crate::prelude::render::*;
 
 impl<'root> Renderer<'root, MjHero, ()> {
+    #[cfg(feature = "fragment")]
     fn children_iter(&self) -> impl Iterator<Item = &MjBodyChild> {
         fn folder<'root>(c: &'root MjBodyChild) -> Box<dyn Iterator<Item = &MjBodyChild> + 'root> {
             match c {
@@ -14,6 +15,11 @@ impl<'root> Renderer<'root, MjHero, ()> {
             }
         }
         self.element.children.iter().flat_map(folder)
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children_iter(&self) -> impl Iterator<Item = &MjBodyChild> {
+        self.element.children.iter()
     }
 
     fn set_style_div<'t>(&self, tag: Tag<'t>) -> Tag<'t> {

--- a/packages/mrml-core/src/mj_hero/render.rs
+++ b/packages/mrml-core/src/mj_hero/render.rs
@@ -22,6 +22,16 @@ impl<'root> Renderer<'root, MjHero, ()> {
         self.element.children.iter()
     }
 
+    #[cfg(feature = "fragment")]
+    fn children_count(&self) -> usize {
+        self.children_iter().count()
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children_count(&self) -> usize {
+        self.element.children.len()
+    }
+
     fn set_style_div<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
         tag.add_style("margin", "0 auto").maybe_add_style(
             "max-width",
@@ -157,7 +167,7 @@ impl<'root> Renderer<'root, MjHero, ()> {
     }
 
     fn render_children(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
-        let siblings = self.children_iter().count();
+        let siblings = self.children_count();
         let raw_siblings = self.children_iter().filter(|c| c.is_raw()).count();
         for (index, child) in self.children_iter().enumerate() {
             let mut renderer = child.renderer(self.context());

--- a/packages/mrml-core/src/mj_hero/render.rs
+++ b/packages/mrml-core/src/mj_hero/render.rs
@@ -6,20 +6,14 @@ use crate::mj_body::MjBodyChild;
 use crate::prelude::render::*;
 
 impl<'root> Renderer<'root, MjHero, ()> {
-    fn get_children(&self) -> Vec<&MjBodyChild> {
-        fn folder<'root>(
-            mut acc: Vec<&'root MjBodyChild>,
-            c: &'root MjBodyChild,
-        ) -> Vec<&'root MjBodyChild> {
+    fn children_iter(&self) -> impl Iterator<Item = &MjBodyChild> {
+        fn folder<'root>(c: &'root MjBodyChild) -> Box<dyn Iterator<Item = &MjBodyChild> + 'root> {
             match c {
-                MjBodyChild::Fragment(f) => {
-                    acc.append(&mut f.children.iter().fold(Vec::new(), folder))
-                }
-                _ => acc.push(c),
+                MjBodyChild::Fragment(f) => Box::new(f.children.iter().flat_map(folder)),
+                _ => Box::new(std::iter::once(c)),
             }
-            acc
         }
-        self.element.children.iter().fold(Vec::new(), folder)
+        self.element.children.iter().flat_map(folder)
     }
 
     fn set_style_div<'t>(&self, tag: Tag<'t>) -> Tag<'t> {
@@ -157,10 +151,9 @@ impl<'root> Renderer<'root, MjHero, ()> {
     }
 
     fn render_children(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
-        let children = self.get_children();
-        let siblings = children.len();
-        let raw_siblings = children.iter().filter(|c| c.is_raw()).count();
-        for (index, child) in children.iter().enumerate() {
+        let siblings = self.children_iter().count();
+        let raw_siblings = self.children_iter().filter(|c| c.is_raw()).count();
+        for (index, child) in self.children_iter().enumerate() {
             let mut renderer = child.renderer(self.context());
             renderer.set_index(index);
             renderer.set_siblings(siblings);

--- a/packages/mrml-core/src/mj_include/body/mod.rs
+++ b/packages/mrml-core/src/mj_include/body/mod.rs
@@ -15,6 +15,7 @@ use super::NAME;
 #[cfg_attr(feature = "json", serde(untagged))]
 pub enum MjIncludeBodyChild {
     Comment(crate::comment::Comment),
+    Fragment(crate::fragment::Fragment<Self>),
     MjAccordion(crate::mj_accordion::MjAccordion),
     MjButton(crate::mj_button::MjButton),
     MjCarousel(crate::mj_carousel::MjCarousel),

--- a/packages/mrml-core/src/mj_include/body/mod.rs
+++ b/packages/mrml-core/src/mj_include/body/mod.rs
@@ -15,6 +15,7 @@ use super::NAME;
 #[cfg_attr(feature = "json", serde(untagged))]
 pub enum MjIncludeBodyChild {
     Comment(crate::comment::Comment),
+    #[cfg(feature = "fragment")]
     Fragment(crate::fragment::Fragment<Self>),
     MjAccordion(crate::mj_accordion::MjAccordion),
     MjButton(crate::mj_button::MjButton),

--- a/packages/mrml-core/src/mj_include/body/parse.rs
+++ b/packages/mrml-core/src/mj_include/body/parse.rs
@@ -51,6 +51,7 @@ impl<'opts> ParseElement<MjIncludeBodyChild> for MrmlParser<'opts> {
             MJ_TABLE => Ok(MjIncludeBodyChild::MjTable(self.parse(cursor, tag)?)),
             MJ_TEXT => Ok(MjIncludeBodyChild::MjText(self.parse(cursor, tag)?)),
             MJ_WRAPPER => Ok(MjIncludeBodyChild::MjWrapper(self.parse(cursor, tag)?)),
+            _ if tag.is_empty() => Ok(MjIncludeBodyChild::Fragment(self.parse(cursor, tag)?)),
             _ => Err(Error::UnexpectedElement(tag.into())),
         }
     }
@@ -112,6 +113,9 @@ impl AsyncParseElement<MjIncludeBodyChild> for AsyncMrmlParser {
                 self.async_parse(cursor, tag).await?,
             )),
             MJ_WRAPPER => Ok(MjIncludeBodyChild::MjWrapper(
+                self.async_parse(cursor, tag).await?,
+            )),
+            _ if tag.is_empty() => Ok(MjIncludeBodyChild::Fragment(
                 self.async_parse(cursor, tag).await?,
             )),
             _ => Err(Error::UnexpectedElement(tag.into())),

--- a/packages/mrml-core/src/mj_include/body/parse.rs
+++ b/packages/mrml-core/src/mj_include/body/parse.rs
@@ -51,6 +51,7 @@ impl<'opts> ParseElement<MjIncludeBodyChild> for MrmlParser<'opts> {
             MJ_TABLE => Ok(MjIncludeBodyChild::MjTable(self.parse(cursor, tag)?)),
             MJ_TEXT => Ok(MjIncludeBodyChild::MjText(self.parse(cursor, tag)?)),
             MJ_WRAPPER => Ok(MjIncludeBodyChild::MjWrapper(self.parse(cursor, tag)?)),
+            #[cfg(feature = "fragment")]
             _ if tag.is_empty() => Ok(MjIncludeBodyChild::Fragment(self.parse(cursor, tag)?)),
             _ => Err(Error::UnexpectedElement(tag.into())),
         }
@@ -115,6 +116,7 @@ impl AsyncParseElement<MjIncludeBodyChild> for AsyncMrmlParser {
             MJ_WRAPPER => Ok(MjIncludeBodyChild::MjWrapper(
                 self.async_parse(cursor, tag).await?,
             )),
+            #[cfg(feature = "fragment")]
             _ if tag.is_empty() => Ok(MjIncludeBodyChild::Fragment(
                 self.async_parse(cursor, tag).await?,
             )),

--- a/packages/mrml-core/src/mj_include/body/render.rs
+++ b/packages/mrml-core/src/mj_include/body/render.rs
@@ -7,6 +7,7 @@ impl MjIncludeBodyChild {
     ) -> &'root (dyn Renderable<'render, 'root> + 'root) {
         match self {
             Self::Comment(elt) => elt,
+            #[cfg(feature = "fragment")]
             Self::Fragment(elt) => elt,
             Self::MjAccordion(elt) => elt,
             Self::MjButton(elt) => elt,
@@ -43,6 +44,7 @@ impl<'render, 'root: 'render> Renderable<'render, 'root> for MjIncludeBodyChild 
     }
 }
 impl<'root> Renderer<'root, MjIncludeBody, ()> {
+    #[cfg(feature = "fragment")]
     fn children_iter(&self) -> impl Iterator<Item = &MjIncludeBodyChild> {
         fn folder<'root>(
             c: &'root MjIncludeBodyChild,
@@ -53,6 +55,11 @@ impl<'root> Renderer<'root, MjIncludeBody, ()> {
             }
         }
         self.element.children.iter().flat_map(folder)
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children_iter(&self) -> impl Iterator<Item = &MjIncludeBodyChild> {
+        self.element.children.iter()
     }
 }
 

--- a/packages/mrml-core/src/mj_include/head/mod.rs
+++ b/packages/mrml-core/src/mj_include/head/mod.rs
@@ -16,6 +16,7 @@ use super::NAME;
 #[cfg_attr(feature = "render", derive(enum_as_inner::EnumAsInner))]
 pub enum MjIncludeHeadChild {
     Comment(crate::comment::Comment),
+    #[cfg(feature = "fragment")]
     Fragment(crate::fragment::Fragment<Self>),
     MjAttributes(crate::mj_attributes::MjAttributes),
     MjBreakpoint(crate::mj_breakpoint::MjBreakpoint),

--- a/packages/mrml-core/src/mj_include/head/mod.rs
+++ b/packages/mrml-core/src/mj_include/head/mod.rs
@@ -16,6 +16,7 @@ use super::NAME;
 #[cfg_attr(feature = "render", derive(enum_as_inner::EnumAsInner))]
 pub enum MjIncludeHeadChild {
     Comment(crate::comment::Comment),
+    Fragment(crate::fragment::Fragment<Self>),
     MjAttributes(crate::mj_attributes::MjAttributes),
     MjBreakpoint(crate::mj_breakpoint::MjBreakpoint),
     MjFont(crate::mj_font::MjFont),

--- a/packages/mrml-core/src/mj_include/head/parse.rs
+++ b/packages/mrml-core/src/mj_include/head/parse.rs
@@ -36,6 +36,7 @@ impl<'opts> ParseElement<MjIncludeHeadChild> for MrmlParser<'opts> {
             MJ_RAW => self.parse(cursor, tag).map(MjIncludeHeadChild::MjRaw),
             MJ_STYLE => self.parse(cursor, tag).map(MjIncludeHeadChild::MjStyle),
             MJ_TITLE => self.parse(cursor, tag).map(MjIncludeHeadChild::MjTitle),
+            #[cfg(feature = "fragment")]
             _ if tag.is_empty() => Ok(MjIncludeHeadChild::Fragment(self.parse(cursor, tag)?)),
             _ => Err(Error::UnexpectedElement(tag.into())),
         }
@@ -81,6 +82,7 @@ impl AsyncParseElement<MjIncludeHeadChild> for AsyncMrmlParser {
                 .await
                 .map(MjIncludeHeadChild::MjTitle),
 
+            #[cfg(feature = "fragment")]
             _ if tag.is_empty() => Ok(MjIncludeHeadChild::Fragment(
                 self.async_parse(cursor, tag).await?,
             )),

--- a/packages/mrml-core/src/mj_include/head/parse.rs
+++ b/packages/mrml-core/src/mj_include/head/parse.rs
@@ -36,6 +36,7 @@ impl<'opts> ParseElement<MjIncludeHeadChild> for MrmlParser<'opts> {
             MJ_RAW => self.parse(cursor, tag).map(MjIncludeHeadChild::MjRaw),
             MJ_STYLE => self.parse(cursor, tag).map(MjIncludeHeadChild::MjStyle),
             MJ_TITLE => self.parse(cursor, tag).map(MjIncludeHeadChild::MjTitle),
+            _ if tag.is_empty() => Ok(MjIncludeHeadChild::Fragment(self.parse(cursor, tag)?)),
             _ => Err(Error::UnexpectedElement(tag.into())),
         }
     }
@@ -79,6 +80,10 @@ impl AsyncParseElement<MjIncludeHeadChild> for AsyncMrmlParser {
                 .async_parse(cursor, tag)
                 .await
                 .map(MjIncludeHeadChild::MjTitle),
+
+            _ if tag.is_empty() => Ok(MjIncludeHeadChild::Fragment(
+                self.async_parse(cursor, tag).await?,
+            )),
             _ => Err(Error::UnexpectedElement(tag.into())),
         }
     }

--- a/packages/mrml-core/src/mj_include/head/print.rs
+++ b/packages/mrml-core/src/mj_include/head/print.rs
@@ -1,5 +1,4 @@
 use super::MjIncludeHeadKind;
-
 use crate::prelude::print::{PrintableAttributes, PrintableElement};
 
 impl PrintableElement for super::MjIncludeHead {

--- a/packages/mrml-core/src/mj_raw/children.rs
+++ b/packages/mrml-core/src/mj_raw/children.rs
@@ -1,4 +1,5 @@
 use crate::comment::Comment;
+use crate::fragment::Fragment;
 use crate::node::Node;
 use crate::text::Text;
 
@@ -8,6 +9,7 @@ use crate::text::Text;
 #[cfg_attr(feature = "print", enum_dispatch::enum_dispatch)]
 pub enum MjRawChild {
     Comment(Comment),
+    Fragment(Fragment<Self>),
     Node(Node<MjRawChild>),
     Text(Text),
 }

--- a/packages/mrml-core/src/mj_raw/children.rs
+++ b/packages/mrml-core/src/mj_raw/children.rs
@@ -1,4 +1,5 @@
 use crate::comment::Comment;
+#[cfg(feature = "fragment")]
 use crate::fragment::Fragment;
 use crate::node::Node;
 use crate::text::Text;
@@ -9,6 +10,7 @@ use crate::text::Text;
 #[cfg_attr(feature = "print", enum_dispatch::enum_dispatch)]
 pub enum MjRawChild {
     Comment(Comment),
+    #[cfg(feature = "fragment")]
     Fragment(Fragment<Self>),
     Node(Node<MjRawChild>),
     Text(Text),

--- a/packages/mrml-core/src/mj_raw/parse.rs
+++ b/packages/mrml-core/src/mj_raw/parse.rs
@@ -2,6 +2,7 @@ use xmlparser::StrSpan;
 
 use super::{MjRaw, MjRawChild};
 use crate::comment::Comment;
+
 use crate::node::Node;
 use crate::prelude::is_void_element;
 #[cfg(feature = "async")]

--- a/packages/mrml-core/src/mj_raw/render.rs
+++ b/packages/mrml-core/src/mj_raw/render.rs
@@ -32,6 +32,16 @@ impl<'root> Renderer<'root, MjRaw, ()> {
     fn children_iter(&self) -> impl Iterator<Item = &MjRawChild> {
         self.element.children.iter()
     }
+
+    #[cfg(feature = "fragment")]
+    fn children_count(&self) -> usize {
+        self.children_iter().count()
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children_count(&self) -> usize {
+        self.element.children.len()
+    }
 }
 
 impl<'root> Render<'root> for Renderer<'root, MjRaw, ()> {
@@ -48,7 +58,7 @@ impl<'root> Render<'root> for Renderer<'root, MjRaw, ()> {
     }
 
     fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
-        let siblings = self.children_iter().count();
+        let siblings = self.children_count();
         for (index, child) in self.children_iter().enumerate() {
             let mut renderer = child.renderer(self.context());
             renderer.set_index(index);

--- a/packages/mrml-core/src/mj_raw/render.rs
+++ b/packages/mrml-core/src/mj_raw/render.rs
@@ -9,6 +9,7 @@ impl<'render, 'root: 'render> Renderable<'render, 'root> for MjRawChild {
     ) -> Box<dyn Render<'root> + 'render> {
         match self {
             Self::Comment(elt) => elt.renderer(context),
+            #[cfg(feature = "fragment")]
             Self::Fragment(elt) => elt.renderer(context),
             Self::Node(elt) => elt.renderer(context),
             Self::Text(elt) => elt.renderer(context),
@@ -16,6 +17,7 @@ impl<'render, 'root: 'render> Renderable<'render, 'root> for MjRawChild {
     }
 }
 impl<'root> Renderer<'root, MjRaw, ()> {
+    #[cfg(feature = "fragment")]
     fn children_iter(&self) -> impl Iterator<Item = &MjRawChild> {
         fn folder<'root>(c: &'root MjRawChild) -> Box<dyn Iterator<Item = &MjRawChild> + 'root> {
             match c {
@@ -24,6 +26,11 @@ impl<'root> Renderer<'root, MjRaw, ()> {
             }
         }
         self.element.children.iter().flat_map(folder)
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children_iter(&self) -> impl Iterator<Item = &MjRawChild> {
+        self.element.children.iter()
     }
 }
 

--- a/packages/mrml-core/src/mj_section/render.rs
+++ b/packages/mrml-core/src/mj_section/render.rs
@@ -510,6 +510,7 @@ pub trait SectionLikeRender<'root>: WithMjSectionBackground<'root> {
 
 impl<'root> WithMjSectionBackground<'root> for Renderer<'root, MjSection, ()> {}
 impl<'root> SectionLikeRender<'root> for Renderer<'root, MjSection, ()> {
+    #[cfg(feature = "fragment")]
     fn children(&self) -> Vec<&crate::mj_body::MjBodyChild> {
         fn folder<'root>(
             mut acc: Vec<&'root MjBodyChild>,
@@ -524,6 +525,11 @@ impl<'root> SectionLikeRender<'root> for Renderer<'root, MjSection, ()> {
             acc
         }
         self.element.children.iter().fold(Vec::new(), folder)
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children(&self) -> Vec<&MjBodyChild> {
+        self.element.children.iter().collect()
     }
 
     fn container_width(&self) -> &Option<Pixel> {

--- a/packages/mrml-core/src/mj_social/children.rs
+++ b/packages/mrml-core/src/mj_social/children.rs
@@ -1,4 +1,5 @@
 use crate::comment::Comment;
+use crate::fragment::Fragment;
 use crate::mj_social_element::MjSocialElement;
 
 #[derive(Debug)]
@@ -7,5 +8,6 @@ use crate::mj_social_element::MjSocialElement;
 #[cfg_attr(feature = "print", enum_dispatch::enum_dispatch)]
 pub enum MjSocialChild {
     Comment(Comment),
+    Fragment(Fragment<Self>),
     MjSocialElement(MjSocialElement),
 }

--- a/packages/mrml-core/src/mj_social/children.rs
+++ b/packages/mrml-core/src/mj_social/children.rs
@@ -1,4 +1,5 @@
 use crate::comment::Comment;
+#[cfg(feature = "fragment")]
 use crate::fragment::Fragment;
 use crate::mj_social_element::MjSocialElement;
 
@@ -8,6 +9,7 @@ use crate::mj_social_element::MjSocialElement;
 #[cfg_attr(feature = "print", enum_dispatch::enum_dispatch)]
 pub enum MjSocialChild {
     Comment(Comment),
+    #[cfg(feature = "fragment")]
     Fragment(Fragment<Self>),
     MjSocialElement(MjSocialElement),
 }

--- a/packages/mrml-core/src/mj_social/render.rs
+++ b/packages/mrml-core/src/mj_social/render.rs
@@ -9,6 +9,7 @@ impl<'render, 'root: 'render> Renderable<'render, 'root> for MjSocialChild {
     ) -> Box<dyn Render<'root> + 'render> {
         match self {
             Self::MjSocialElement(elt) => elt.renderer(context),
+            #[cfg(feature = "fragment")]
             Self::Fragment(elt) => elt.renderer(context),
             Self::Comment(elt) => elt.renderer(context),
         }
@@ -47,6 +48,7 @@ const EXTRA_CHILD_KEY: [&str; 13] = [
 ];
 
 impl<'root> Renderer<'root, MjSocial, ()> {
+    #[cfg(feature = "fragment")]
     fn children_iter(&self) -> impl Iterator<Item = &MjSocialChild> {
         fn folder<'root>(
             c: &'root MjSocialChild,
@@ -57,6 +59,11 @@ impl<'root> Renderer<'root, MjSocial, ()> {
             }
         }
         self.element.children.iter().flat_map(folder)
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children_iter(&self) -> impl Iterator<Item = &MjSocialChild> {
+        self.element.children.iter()
     }
 
     fn set_style_table_vertical<'t>(&self, tag: Tag<'t>) -> Tag<'t> {

--- a/packages/mrml-core/src/mj_table/render.rs
+++ b/packages/mrml-core/src/mj_table/render.rs
@@ -7,6 +7,7 @@ use crate::prelude::render::*;
 impl<'root> WithMjSectionBackground<'root> for Renderer<'root, MjTable, ()> {}
 
 impl<'root> Renderer<'root, MjTable, ()> {
+    #[cfg(feature = "fragment")]
     fn children_iter(&self) -> impl Iterator<Item = &MjBodyChild> {
         fn folder<'root>(c: &'root MjBodyChild) -> Box<dyn Iterator<Item = &MjBodyChild> + 'root> {
             match c {
@@ -15,6 +16,11 @@ impl<'root> Renderer<'root, MjTable, ()> {
             }
         }
         self.element.children.iter().flat_map(folder)
+    }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children_iter(&self) -> impl Iterator<Item = &MjBodyChild> {
+        self.element.children.iter()
     }
 
     fn set_style_table<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>

--- a/packages/mrml-core/src/mj_wrapper/render.rs
+++ b/packages/mrml-core/src/mj_wrapper/render.rs
@@ -17,12 +17,14 @@ impl<'root> Renderer<'root, MjWrapper, ()> {
 impl<'root> WithMjSectionBackground<'root> for Renderer<'root, MjWrapper, ()> {}
 
 impl<'root> SectionLikeRender<'root> for Renderer<'root, MjWrapper, ()> {
+    #[cfg(feature = "fragment")]
     fn children(&self) -> Vec<&MjBodyChild> {
         fn folder<'root>(
             mut acc: Vec<&'root MjBodyChild>,
             c: &'root MjBodyChild,
         ) -> Vec<&'root MjBodyChild> {
             match c {
+                #[cfg(feature = "fragment")]
                 MjBodyChild::Fragment(f) => {
                     acc.append(&mut f.children.iter().fold(Vec::new(), folder))
                 }
@@ -32,6 +34,12 @@ impl<'root> SectionLikeRender<'root> for Renderer<'root, MjWrapper, ()> {
         }
         self.element.children.iter().fold(Vec::new(), folder)
     }
+
+    #[cfg(not(feature = "fragment"))]
+    fn children(&self) -> Vec<&MjBodyChild> {
+        self.element.children.iter().collect()
+    }
+
     fn container_width(&self) -> &Option<Pixel> {
         &self.container_width
     }

--- a/packages/mrml-core/src/prelude/print.rs
+++ b/packages/mrml-core/src/prelude/print.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Debug, Display, Write};
 
 // use crate::helper::sort::sort_by_key;
+#[cfg(feature = "fragment")]
 use crate::fragment::Fragment;
 use crate::prelude::hash::Map;
 

--- a/packages/mrml-core/src/prelude/print.rs
+++ b/packages/mrml-core/src/prelude/print.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Debug, Display, Write};
 
 // use crate::helper::sort::sort_by_key;
+use crate::fragment::Fragment;
 use crate::prelude::hash::Map;
 
 pub trait PrintableAttributes {


### PR DESCRIPTION
This component effectively just acts as a collection of children. However, when rendered, they behave as if directly under the parent element. This is useful for passing around reusable components, etc, in Rust code.

Right now, it is not actually possible to parse a Fragment. Instead, they must be constructed by Rust code. This is because of some non-configurable validation in xmlparser:
https://github.com/RazrFalcon/xmlparser/blob/e54c2768f20814140c11e6c92f94ee74bfd54808/src/stream.rs#L432

I'm using this in [mrmx](https://github.com/JadedBlueEyes/mrmx), as it makes it quite a bit more pleasant to use. 

This might have a slight performance impact, as `fn get_children` allocates a Vector to help fold all children and nested Fragment children into one array. Before, this was directly calling `.iter()` on `self.element.children`. However, local benchmarking doesn't find any significant difference. I'm very much open to a different solution, though!

```

     Running benches/basic.rs (C:\Users\jade\.cache\cargo-target\release\deps\basic-9ef9e838d0ba5c55.exe)
Benchmarking render button: Collecting 100 samples in estimated 5.0707 s 
                        time:   [16.882 µs 17.014 µs 17.161 µs]
                        change: [-3.1318% -0.5849% +1.9841%] (p = 0.66 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

     Running benches/template.rs (C:\Users\jade\.cache\cargo-target\release\deps\template-7a43bc935c493ad3.exe)
Benchmarking amario: Collecting 100 samples in estimated 5.4222 s (10k itera
                        time:   [525.70 µs 529.71 µs 534.01 µs]
                        change: [-3.9368% -1.2313% +1.1003%] (p = 0.37 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
```