### PR TITLE
feat(mrml-core): add x to the supported social elements

### DIFF
--- a/packages/mrml-core/src/mj_social_element/network.rs
+++ b/packages/mrml-core/src/mj_social_element/network.rs
@@ -47,6 +47,7 @@ impl SocialNetwork {
             "web" => Some(Self::web()),
             "xing" => Some(Self::xing(noshare)),
             "youtube" => Some(Self::youtube()),
+            "x" => Some(Self::x(noshare)),
             _ => None,
         }
     }
@@ -168,6 +169,19 @@ impl SocialNetwork {
                 Some("https://twitter.com/home?status=[[URL]]")
             },
             icon: "twitter.png",
+        }
+    }
+
+
+    fn x(noshare: bool) -> Self {
+        Self {
+            background_color: "#000000",
+            share_url: if noshare {
+                None
+            } else {
+                Some("https://twitter.com/home?status=[[URL]]")
+            },
+            icon: "twitter-x.png",
         }
     }
 

--- a/packages/mrml-core/src/mj_social_element/network.rs
+++ b/packages/mrml-core/src/mj_social_element/network.rs
@@ -172,7 +172,6 @@ impl SocialNetwork {
         }
     }
 
-
     fn x(noshare: bool) -> Self {
         Self {
             background_color: "#000000",


### PR DESCRIPTION
Just ported the MJML original javascript code for the social element