### PR TITLE
fix(mrml-core): comments in mrml component should be ignored

### DIFF
--- a/packages/mrml-core/src/mjml/parse.rs
+++ b/packages/mrml-core/src/mjml/parse.rs
@@ -44,6 +44,12 @@ impl<'opts> ParseChildren<MjmlChildren> for MrmlParser<'opts> {
                     cursor.rewind(MrmlToken::ElementClose(close));
                     return Ok(children);
                 }
+                MrmlToken::Text(inner) if inner.text.trim().is_empty() => {
+                    // ignoring empty text
+                }
+                MrmlToken::Comment(_) => {
+                    // ignoring comment on purpose
+                }
                 MrmlToken::ElementStart(start) => match start.local.as_str() {
                     MJ_HEAD => {
                         children.head = Some(self.parse(cursor, start.local)?);

--- a/packages/mrml-core/tests/issue-474.rs
+++ b/packages/mrml-core/tests/issue-474.rs
@@ -1,0 +1,13 @@
+#![cfg(feature = "parse")]
+
+#[test]
+fn should_preserve_comment() {
+    let template = r#"<mjml>
+    <mj-head>
+    </mj-head>
+    <mj-body>
+    </mj-body> <!-- Here -->
+</mjml>"#;
+
+    let _root = mrml::parse(template).unwrap();
+}


### PR DESCRIPTION
Fixing #474 