### PR TITLE
fix: update documentation to match API change in version 0.2

### DIFF
--- a/packages/mrml-python/readme.md
+++ b/packages/mrml-python/readme.md
@@ -11,12 +11,12 @@ import mrml
 
 # without options
 result = mrml.to_html("<mjml></mjml>")
-assert result.startswith("<!doctype html>")
+assert result.content.startswith("<!doctype html>")
 
 # with options
 parser_options = mrml.ParserOptions(include_loader = mrml.memory_loader({
     'hello-world.mjml': '<mj-text>Hello World!</mj-text>',
 }))
 result = mrml.to_html("<mjml><mj-body><mj-include path=\"hello-world.mjml\" /></mj-body></mjml>", parser_options = parser_options)
-assert result.startswith("<!doctype html>")
+assert result.content.startswith("<!doctype html>")
 ```


### PR DESCRIPTION
I've come across this change when the nightly CI for wagtail-newsletter started failing: https://github.com/wagtail/wagtail-newsletter/actions/workflows/nightly.yml.
