### PR TITLE
feat: enabling conditional comments

### DIFF
--- a/.github/workflows/mrml-cli-main.yml
+++ b/.github/workflows/mrml-cli-main.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdrouet/action-git-metrics@install
+        continue-on-error: true
       - uses: jdrouet/action-git-identity@main
 
       - uses: actions-rs/toolchain@v1

--- a/packages/mrml-core/resources/compare/success/mj-raw-conditional-comment.html
+++ b/packages/mrml-core/resources/compare/success/mj-raw-conditional-comment.html
@@ -1,0 +1,36 @@
+<!doctype html><html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head><title></title><!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]--><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<style type="text/css">
+#outlook a { padding: 0; }
+body { margin: 0; padding: 0; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+table, td { border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+img { border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; -ms-interpolation-mode: bicubic; }
+p { display: block; margin: 13px 0; }
+</style>
+<!--[if mso]>
+<noscript>
+<xml>
+<o:OfficeDocumentSettings>
+  <o:AllowPNG/>
+  <o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml>
+</noscript>
+<![endif]-->
+<!--[if lte mso 11]>
+<style type="text/css">
+.mj-outlook-group-fix { width:100% !important; }
+</style>
+<![endif]-->
+<!--[if !mso]><!--><link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css"><style type="text/css">@import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);</style><!--<![endif]--><style type="text/css">@media only screen and (min-width:480px) { .mj-column-per-100 { width:100% !important; max-width:100%; }  }</style><style media="screen and (min-width:480px)">.moz-text-html .mj-column-per-100 { width:100% !important; max-width:100%; } </style><style type="text/css"></style></head><body style="word-spacing:normal;"><div><!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" align="center" width="600" style="width:600px;"><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]--><div style="margin:0px auto;max-width:600px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" align="center" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+ <!--[if mso | IE]>
+   <table border="0" cellpadding="0" cellspacing="0" role="presentation"><tr>
+    <td><![endif]-->
+    <!--[if mso]>--><div>mso</div><!--<![endif]-->
+    <span>general</span>
+    <!--[if mso]><div><![endif]-->
+    <span>general two</span>
+    <!--[if mso]></div><![endif]-->
+    <!--[if mso | IE]></td>
+    <td><![endif]--><img src="bananas" alt="" /><!--[if mso | IE]></td>
+  </tr></table>
+    <![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--><!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" align="center" width="600" style="width:600px;"><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]--><div style="margin:0px auto;max-width:600px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" align="center" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"><!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation"><tr><td style="vertical-align:top;width:600px;"><![endif]--><div class="mj-outlook-group-fix mj-column-per-100" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%" style="vertical-align:top;"><tbody><tr><td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"><div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">After</div></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></div></body></html>

--- a/packages/mrml-core/resources/compare/success/mj-raw-conditional-comment.mjml
+++ b/packages/mrml-core/resources/compare/success/mj-raw-conditional-comment.mjml
@@ -1,0 +1,23 @@
+<mjml>
+    <mj-head>
+    </mj-head>
+    <mj-body>
+        <mj-section>
+            <mj-raw>
+                <!--[if mso]>--><div>mso</div><!--<![endif]-->
+                <span>general</span>
+                <!--[if mso]><div><![endif]-->
+                <span>general two</span>
+                <!--[if mso]></div><![endif]-->
+            </mj-raw>
+            <mj-raw>
+                <img src="bananas" alt=""/>
+            </mj-raw>
+        </mj-section>
+        <mj-section>
+            <mj-column>
+                <mj-text>After</mj-text>
+            </mj-column>
+        </mj-section>
+    </mj-body>
+</mjml>

--- a/packages/mrml-core/src/conditional_comment/json.rs
+++ b/packages/mrml-core/src/conditional_comment/json.rs
@@ -1,0 +1,61 @@
+use std::fmt;
+
+use serde::de::{Error, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::ConditionalComment;
+
+impl Serialize for ConditionalComment {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+#[derive(Default)]
+struct ConditionalCommentVisitor;
+
+impl Visitor<'_> for ConditionalCommentVisitor {
+    type Value = ConditionalComment;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("an map with properties type and children")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(ConditionalComment(value.to_string()))
+    }
+}
+
+impl<'de> Deserialize<'de> for ConditionalComment {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(ConditionalCommentVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::conditional_comment::ConditionalComment;
+
+    #[test]
+    fn serialize() {
+        let elt = ConditionalComment("<![endif]-->".to_string());
+        assert_eq!(serde_json::to_string(&elt).unwrap(), r#""<![endif]-->""#);
+    }
+
+    #[test]
+    fn deserialize() {
+        let elt = ConditionalComment("<!--[if IE]>".to_string());
+        let json = serde_json::to_string(&elt).unwrap();
+        let res: ConditionalComment = serde_json::from_str(&json).unwrap();
+        assert_eq!(res.0, elt.0);
+    }
+}

--- a/packages/mrml-core/src/conditional_comment/mod.rs
+++ b/packages/mrml-core/src/conditional_comment/mod.rs
@@ -14,12 +14,6 @@ impl ConditionalComment {
     }
 }
 
-impl AsRef<str> for ConditionalComment {
-    fn as_ref(&self) -> &str {
-        self.0.as_str()
-    }
-}
-
 impl<V: Into<String>> From<V> for ConditionalComment {
     fn from(value: V) -> Self {
         Self(value.into())

--- a/packages/mrml-core/src/conditional_comment/mod.rs
+++ b/packages/mrml-core/src/conditional_comment/mod.rs
@@ -1,0 +1,27 @@
+#[cfg(feature = "json")]
+mod json;
+#[cfg(feature = "print")]
+mod print;
+#[cfg(feature = "render")]
+mod render;
+
+#[derive(Clone, Debug, Default)]
+pub struct ConditionalComment(String);
+
+impl ConditionalComment {
+    pub fn inner_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for ConditionalComment {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl<V: Into<String>> From<V> for ConditionalComment {
+    fn from(value: V) -> Self {
+        Self(value.into())
+    }
+}

--- a/packages/mrml-core/src/conditional_comment/print.rs
+++ b/packages/mrml-core/src/conditional_comment/print.rs
@@ -1,0 +1,23 @@
+use super::ConditionalComment;
+use crate::prelude::print::{Printable, Printer};
+
+impl Printable for ConditionalComment {
+    fn print<P: Printer>(&self, printer: &mut P) -> std::fmt::Result {
+        printer.push_indent();
+        printer.push_str(self.0.as_str());
+        printer.push_new_line();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::conditional_comment::ConditionalComment;
+    use crate::prelude::print::Printable;
+
+    #[test]
+    fn empty() {
+        let item = ConditionalComment::from("<!--[if mso]>");
+        assert_eq!("<!--[if mso]>", item.print_dense().unwrap());
+    }
+}

--- a/packages/mrml-core/src/conditional_comment/render.rs
+++ b/packages/mrml-core/src/conditional_comment/render.rs
@@ -40,6 +40,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn render_when_inside_mj_raw() {
         let opts = RenderOptions::default();
         let root = Mjml::parse(r#"<mjml><mj-body><mj-raw><!--[if mso]><span>SpanContent</span><![endif]--></mj-raw></mj-body></mjml>"#).unwrap();

--- a/packages/mrml-core/src/conditional_comment/render.rs
+++ b/packages/mrml-core/src/conditional_comment/render.rs
@@ -23,8 +23,10 @@ impl<'render, 'root: 'render> Renderable<'render, 'root> for ConditionalComment 
 
 #[cfg(all(test, feature = "parse"))]
 mod tests {
+    use crate::conditional_comment::ConditionalComment;
+    use crate::mj_head::MjHead;
     use crate::mjml::Mjml;
-    use crate::prelude::render::RenderOptions;
+    use crate::prelude::render::{Header, RenderContext, RenderCursor, RenderOptions, Renderable};
 
     #[test]
     fn render_fails_without_mj_raw() {
@@ -57,5 +59,24 @@ mod tests {
         let root = Mjml::parse(r#"<mjml><mj-body><mj-raw><!--[if mso]><!-- Comment --><span>SpanContent</span><![endif]--></mj-raw></mj-body></mjml>"#).unwrap();
         let result = root.element.render(&opts).unwrap();
         assert!(result.contains("<!--[if mso]><span>SpanContent</span><![endif]-->"));
+    }
+
+    #[test]
+    fn render_context() {
+        let opts = RenderOptions::default();
+        let mj_head = Some(MjHead::default());
+        let header = Header::new(mj_head.as_ref(), None);
+        let context = RenderContext::new(&opts, header);
+
+        let content = "<!--[if mso]><span>Test Content</span><![endif]-->";
+        let elt = ConditionalComment::from(content);
+        let renderer = elt.renderer(&context);
+
+        assert!(std::ptr::eq(renderer.context(), &context));
+
+        let mut cursor = RenderCursor::default();
+        renderer.render(&mut cursor).unwrap();
+
+        assert_eq!(cursor.buffer.as_ref(), content);
     }
 }

--- a/packages/mrml-core/src/conditional_comment/render.rs
+++ b/packages/mrml-core/src/conditional_comment/render.rs
@@ -13,10 +13,6 @@ impl<'root> Render<'root> for Renderer<'root, ConditionalComment, ()> {
 }
 
 impl<'render, 'root: 'render> Renderable<'render, 'root> for ConditionalComment {
-    fn is_raw(&'root self) -> bool {
-        true
-    }
-
     fn renderer(
         &'root self,
         context: &'root RenderContext<'root>,

--- a/packages/mrml-core/src/conditional_comment/render.rs
+++ b/packages/mrml-core/src/conditional_comment/render.rs
@@ -1,0 +1,26 @@
+use super::ConditionalComment;
+use crate::prelude::render::*;
+
+impl<'root> Render<'root> for Renderer<'root, ConditionalComment, ()> {
+    fn context(&self) -> &'root RenderContext<'root> {
+        self.context
+    }
+
+    fn render(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
+        cursor.buffer.push_str(self.element.inner_str());
+        Ok(())
+    }
+}
+
+impl<'render, 'root: 'render> Renderable<'render, 'root> for ConditionalComment {
+    fn is_raw(&'root self) -> bool {
+        true
+    }
+
+    fn renderer(
+        &'root self,
+        context: &'root RenderContext<'root>,
+    ) -> Box<dyn Render<'root> + 'render> {
+        Box::new(Renderer::new(context, self, ()))
+    }
+}

--- a/packages/mrml-core/src/lib.rs
+++ b/packages/mrml-core/src/lib.rs
@@ -125,6 +125,7 @@
 //! one (and WebAssembly one) can be.
 
 pub mod comment;
+pub mod conditional_comment;
 pub mod mj_accordion;
 pub mod mj_accordion_element;
 pub mod mj_accordion_text;

--- a/packages/mrml-core/src/mj_raw/children.rs
+++ b/packages/mrml-core/src/mj_raw/children.rs
@@ -1,4 +1,5 @@
 use crate::comment::Comment;
+use crate::conditional_comment::ConditionalComment;
 use crate::node::Node;
 use crate::text::Text;
 
@@ -7,6 +8,7 @@ use crate::text::Text;
 #[cfg_attr(feature = "json", serde(untagged))]
 #[cfg_attr(feature = "print", enum_dispatch::enum_dispatch)]
 pub enum MjRawChild {
+    ConditionalComment(ConditionalComment),
     Comment(Comment),
     Node(Node<MjRawChild>),
     Text(Text),

--- a/packages/mrml-core/src/mj_raw/parse.rs
+++ b/packages/mrml-core/src/mj_raw/parse.rs
@@ -154,3 +154,32 @@ impl AsyncParseChildren<Vec<MjRawChild>> for AsyncMrmlParser {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::mj_raw::MjRaw;
+
+    crate::should_parse!(
+        should_parse_start_conditional_comment_child,
+        MjRaw,
+        "<mj-raw><!--[if mso]></mj-raw>"
+    );
+
+    crate::should_parse!(
+        should_parse_end_conditional_comment_child,
+        MjRaw,
+        "<mj-raw><![endif]--></mj-raw>"
+    );
+
+    crate::should_parse!(
+        should_parse_conditional_comment_children,
+        MjRaw,
+        "<mj-raw><!--[if mso]>--><!--[if mso]><!--<![endif]--></mj-raw>"
+    );
+
+    crate::should_not_parse!(
+        should_not_parse_malformed_conditional_comment_child,
+        MjRaw,
+        "<mj-raw><!- -[if mso]>--></mj-raw>"
+    );
+}

--- a/packages/mrml-core/src/mj_raw/parse.rs
+++ b/packages/mrml-core/src/mj_raw/parse.rs
@@ -2,6 +2,7 @@ use htmlparser::StrSpan;
 
 use super::MjRawChild;
 use crate::comment::Comment;
+use crate::conditional_comment::ConditionalComment;
 use crate::node::Node;
 use crate::prelude::is_void_element;
 #[cfg(feature = "async")]
@@ -87,11 +88,21 @@ impl ParseChildren<Vec<MjRawChild>> for MrmlParser<'_> {
                     cursor.rewind(MrmlToken::ElementClose(close));
                     return Ok(children);
                 }
+                MrmlToken::ConditionalCommentStart(start) => {
+                    children.push(MjRawChild::ConditionalComment(ConditionalComment::from(
+                        start.span.as_str(),
+                    )));
+                }
+                MrmlToken::ConditionalCommentEnd(end) => {
+                    children.push(MjRawChild::ConditionalComment(ConditionalComment::from(
+                        end.span.as_str(),
+                    )));
+                }
                 other => {
                     return Err(Error::UnexpectedToken {
                         origin: cursor.origin(),
                         position: other.span(),
-                    })
+                    });
                 }
             }
         }
@@ -122,6 +133,16 @@ impl AsyncParseChildren<Vec<MjRawChild>> for AsyncMrmlParser {
                 MrmlToken::ElementClose(close) => {
                     cursor.rewind(MrmlToken::ElementClose(close));
                     return Ok(children);
+                }
+                MrmlToken::ConditionalCommentStart(start) => {
+                    children.push(MjRawChild::ConditionalComment(ConditionalComment::from(
+                        start.span.as_str(),
+                    )));
+                }
+                MrmlToken::ConditionalCommentEnd(end) => {
+                    children.push(MjRawChild::ConditionalComment(ConditionalComment::from(
+                        end.span.as_str(),
+                    )));
                 }
                 other => {
                     return Err(Error::UnexpectedToken {

--- a/packages/mrml-core/src/mj_raw/render.rs
+++ b/packages/mrml-core/src/mj_raw/render.rs
@@ -8,6 +8,7 @@ impl<'render, 'root: 'render> Renderable<'render, 'root> for MjRawChild {
         context: &'root RenderContext<'root>,
     ) -> Box<dyn Render<'root> + 'render> {
         match self {
+            Self::ConditionalComment(elt) => elt.renderer(context),
             Self::Comment(elt) => elt.renderer(context),
             Self::Node(elt) => elt.renderer(context),
             Self::Text(elt) => elt.renderer(context),
@@ -55,4 +56,5 @@ impl<'render, 'root: 'render> Renderable<'render, 'root> for MjRaw {
 mod tests {
     crate::should_render!(basic, "mj-raw");
     crate::should_render!(in_head, "mj-raw-head");
+    crate::should_render!(conditional_comment, "mj-raw-conditional-comment");
 }

--- a/packages/mrml-core/src/prelude/parser/token.rs
+++ b/packages/mrml-core/src/prelude/parser/token.rs
@@ -58,6 +58,8 @@ impl<'a> From<Token<'a>> for Span {
 #[derive(Debug)]
 pub(crate) enum MrmlToken<'a> {
     Attribute(Attribute<'a>),
+    ConditionalCommentEnd(ConditionalCommentEnd<'a>),
+    ConditionalCommentStart(ConditionalCommentStart<'a>),
     Comment(Comment<'a>),
     ElementClose(ElementClose<'a>),
     ElementEnd(ElementEnd<'a>),
@@ -108,6 +110,14 @@ impl<'a> MrmlToken<'a> {
                 local,
                 span,
             })),
+            Token::ConditionalCommentEnd { span } => {
+                Ok(MrmlToken::ConditionalCommentEnd(ConditionalCommentEnd {
+                    span,
+                }))
+            }
+            Token::ConditionalCommentStart { span, condition } => Ok(
+                MrmlToken::ConditionalCommentStart(ConditionalCommentStart { span, condition }),
+            ),
             Token::Text { text } => Ok(MrmlToken::Text(Text { text })),
             other => Err(super::Error::UnexpectedToken {
                 origin: cursor.origin(),
@@ -121,6 +131,8 @@ impl MrmlToken<'_> {
     pub fn span(&self) -> Span {
         match self {
             Self::Attribute(item) => item.span,
+            Self::ConditionalCommentEnd(item) => item.span,
+            Self::ConditionalCommentStart(item) => item.span,
             Self::Comment(item) => item.span,
             Self::ElementClose(item) => item.span,
             Self::ElementEnd(item) => item.span,
@@ -138,6 +150,17 @@ pub(crate) struct Attribute<'a> {
     pub local: StrSpan<'a>,
     pub value: Option<StrSpan<'a>>,
     pub span: StrSpan<'a>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ConditionalCommentEnd<'a> {
+    pub span: StrSpan<'a>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ConditionalCommentStart<'a> {
+    pub span: StrSpan<'a>,
+    pub condition: StrSpan<'a>,
 }
 
 #[derive(Debug)]

--- a/packages/mrml-core/src/prelude/parser/token.rs
+++ b/packages/mrml-core/src/prelude/parser/token.rs
@@ -115,8 +115,8 @@ impl<'a> MrmlToken<'a> {
                     span,
                 }))
             }
-            Token::ConditionalCommentStart { span, condition } => Ok(
-                MrmlToken::ConditionalCommentStart(ConditionalCommentStart { span, condition }),
+            Token::ConditionalCommentStart { span, condition: _ } => Ok(
+                MrmlToken::ConditionalCommentStart(ConditionalCommentStart { span }),
             ),
             Token::Text { text } => Ok(MrmlToken::Text(Text { text })),
             other => Err(super::Error::UnexpectedToken {
@@ -160,7 +160,6 @@ pub(crate) struct ConditionalCommentEnd<'a> {
 #[derive(Debug)]
 pub(crate) struct ConditionalCommentStart<'a> {
     pub span: StrSpan<'a>,
-    pub condition: StrSpan<'a>,
 }
 
 #[derive(Debug)]

--- a/packages/mrml-core/src/prelude/print.rs
+++ b/packages/mrml-core/src/prelude/print.rs
@@ -71,6 +71,7 @@ impl<T: StaticTag, A: PrintableAttributes, C: PrintableChildren> PrintableElemen
 
 use super::StaticTag;
 use crate::comment::Comment;
+use crate::conditional_comment::ConditionalComment;
 use crate::mj_accordion::{MjAccordion, MjAccordionChild};
 use crate::mj_accordion_element::MjAccordionElement;
 use crate::mj_attributes::{MjAttributes, MjAttributesChild};
@@ -108,6 +109,7 @@ use crate::node::Node;
 use crate::text::Text;
 
 #[enum_dispatch::enum_dispatch(
+    ConditionalComment,
     MjAccordionChild,
     MjAttributesChild,
     MjBodyChild,

--- a/packages/mrml-core/src/prelude/print.rs
+++ b/packages/mrml-core/src/prelude/print.rs
@@ -295,7 +295,7 @@ impl Printer for PrettyPrinter {
     #[inline]
     fn push_indent(&mut self) {
         self.buffer
-            .extend(std::iter::repeat(' ').take(self.level * self.indent_size));
+            .extend(std::iter::repeat_n(' ', self.level * self.indent_size));
     }
 
     #[inline]


### PR DESCRIPTION
Fixing #532, trying to make mrml behaving as mjml regarding conditional comments.

Approach:
- Fix: recognize conditional comment tokens.
- Treat them as raw output values (printer/render)
- Don't reuse `Text` as it seemed not semantically correct (however, I was doubting about it)
- Adding a test considering 3 cases:
  - conditional comments surrounded by comments (long format)
  - cond comment with internal proper html (`<div>msgo</div>`)
  - cond comments having separated tags (`<div>` and in other cond comment `</div>`)

However, new to the codebase and at least 3-4 years w/o touching Rust. It was more as an incursion trying to understand the failure in v5.0.0, as part of my free time. But I doubt I could invest much more.

Disclaimer: I needed to explore and code without proper tooling (couldn't build locally, but at least finally got tests passing), so not sure if `cargo fmt` behaved properly, as some warnings appeared regarding nightly channel unstable features.