### PR TITLE
feat(parser): Handle unknown root-level tags gracefully

### DIFF
--- a/packages/mrml-core/src/prelude/parser/output.rs
+++ b/packages/mrml-core/src/prelude/parser/output.rs
@@ -6,11 +6,15 @@ pub struct ParseOutput<E> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WarningKind {
     UnexpectedAttribute,
+    UnknownElement,
 }
 
 impl WarningKind {
     pub const fn as_str(&self) -> &'static str {
-        "unexpected-attribute"
+        match self {
+            Self::UnexpectedAttribute => "unexpected-attribute",
+            Self::UnknownElement => "unknown-element",
+        }
     }
 }
 
@@ -18,6 +22,7 @@ impl std::fmt::Display for WarningKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::UnexpectedAttribute => f.write_str("unexpected attribute"),
+            Self::UnknownElement => f.write_str("unknown element"),
         }
     }
 }

--- a/packages/mrml-core/src/root/parse.rs
+++ b/packages/mrml-core/src/root/parse.rs
@@ -1,8 +1,68 @@
 use super::RootChild;
 use crate::comment::Comment;
 use crate::prelude::parser::{
-    Error, MrmlCursor, MrmlParser, MrmlToken, ParseChildren, ParseOutput, ParserOptions,
+    Error, MrmlCursor, MrmlParser, MrmlToken, ParseChildren, ParseOutput, ParserOptions, WarningKind,
 };
+
+#[inline]
+fn skip_element_and_children(cursor: &mut MrmlCursor<'_>) -> Result<(), Error> {
+    // The initial ElementStart for the unknown tag is already consumed by the caller.
+    // We now need to consume its attributes (if any) and then its children or the closing tag.
+
+    // Consume any attributes associated with the unknown tag.
+    while cursor.next_attribute()?.is_some() {
+        // just consume
+    }
+
+    // Check if the element is self-closing (e.g. <mj-unknown />)
+    // We use assert_element_end which expects either an ElementEndToken::Empty or ElementEndToken::Close
+    // This also consumes the token.
+    let ending_token = cursor.assert_element_end()?;
+    if ending_token.empty {
+        return Ok(()); // Self-closing, nothing more to skip.
+    }
+
+    // Not self-closing, so we need to skip children until the corresponding closing tag.
+    let mut depth = 1;
+    while depth > 0 {
+        match cursor.next_token()? {
+            Some(MrmlToken::ElementStart(_element_start_token)) => {
+                // Consume attributes of this nested element
+                while cursor.next_attribute()?.is_some() {}
+                // Check if this nested element is self-closing
+                let nested_ending = cursor.assert_element_end()?;
+                if !nested_ending.empty {
+                    depth += 1;
+                }
+            }
+            Some(MrmlToken::ElementClose(_element_close_token)) => {
+                depth -= 1;
+            }
+            Some(MrmlToken::Comment(_)) | Some(MrmlToken::Text(_)) => { /* Consume other tokens */ }
+            None => {
+                // This means an unclosed tag while skipping, which is an error.
+                return Err(Error::UnexpectedEofKind {
+                    kind: "element".into(),
+                    position: cursor.span().into(),
+                    origin: cursor.origin(),
+                });
+            }
+            // Any other token type encountered during skipping that isn't explicitly handled above
+            // (like ElementEnd which is handled by assert_element_end) would be an issue.
+            // However, next_token() should cover the main cases.
+            // If an unexpected token type that breaks the structure appears, it might indicate
+            // a problem with the input MJML or the tokenization process itself.
+            // For robustness, we can treat unexpected tokens during skipping as an error.
+            Some(other) => {
+                return Err(Error::UnexpectedToken {
+                    origin: cursor.origin(),
+                    position: other.span(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
 
 impl crate::prelude::parser::ParseChildren<Vec<RootChild>> for MrmlParser<'_> {
     fn parse_children(&self, cursor: &mut MrmlCursor<'_>) -> Result<Vec<RootChild>, Error> {
@@ -14,8 +74,13 @@ impl crate::prelude::parser::ParseChildren<Vec<RootChild>> for MrmlParser<'_> {
                 MrmlToken::Comment(inner) => {
                     result.push(RootChild::Comment(Comment::from(inner.text.as_str())));
                 }
-                MrmlToken::ElementStart(inner) if inner.local.eq("mjml") => {
-                    result.push(RootChild::Mjml(self.parse(cursor, inner.local)?));
+                MrmlToken::ElementStart(inner) => {
+                    if inner.local.eq("mjml") {
+                        result.push(RootChild::Mjml(self.parse(cursor, inner.local)?));
+                    } else {
+                        cursor.add_warning(WarningKind::UnknownElement, inner.span.into());
+                        skip_element_and_children(cursor)?;
+                    }
                 }
                 other => {
                     return Err(Error::UnexpectedToken {
@@ -26,6 +91,198 @@ impl crate::prelude::parser::ParseChildren<Vec<RootChild>> for MrmlParser<'_> {
             }
         }
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::mj_body::MjBody;
+    use crate::mj_text::MjText;
+    use crate::mjml::Mjml;
+    use crate::prelude::parser::{ParserOptions, WarningKind};
+    use crate::root::{Root, RootChild};
+
+    #[test]
+    fn should_warn_and_skip_single_unknown_tag() {
+        let mrml = r#"
+            <mj-unknown></mj-unknown>
+            <mjml>
+                <mj-body>
+                    <mj-text>Hello World</mj-text>
+                </mj-body>
+            </mjml>
+        "#;
+        let opts = ParserOptions::default();
+        let result = Root::parse_with_options(mrml, &opts);
+
+        assert!(result.is_ok());
+        let output = result.unwrap();
+
+        assert_eq!(output.warnings.len(), 1);
+        assert_eq!(output.warnings[0].kind, WarningKind::UnknownElement);
+        assert!(output.warnings[0].to_string().contains("unknown element"));
+        assert!(output.warnings[0].to_string().contains("<mj-unknown>"));
+
+        assert_eq!(output.element.0.len(), 1);
+        match &output.element.0[0] {
+            RootChild::Mjml(mjml_node) => {
+                assert_eq!(mjml_node.children.len(), 1);
+                if let Some(crate::mjml::MjmlChild::MjBody(mj_body)) = &mjml_node.children.get(0) {
+                    assert_eq!(mj_body.children.len(), 1);
+                    if let Some(crate::mj_body::MjBodyChild::MjText(mj_text)) = &mj_body.children.get(0) {
+                        assert_eq!(mj_text.content, "Hello World");
+                    } else {
+                        panic!("Expected MjText");
+                    }
+                } else {
+                    panic!("Expected MjBody");
+                }
+            }
+            _ => panic!("Expected RootChild::Mjml"),
+        }
+    }
+
+    #[test]
+    fn should_warn_and_skip_unknown_tag_with_children() {
+        let mrml = r#"
+            <mj-unknown>
+                <mj-foo>
+                    <mj-bar />
+                </mj-foo>
+            </mj-unknown>
+            <mjml>
+                <mj-body>
+                    <mj-text>Valid Content</mj-text>
+                </mj-body>
+            </mjml>
+        "#;
+        let opts = ParserOptions::default();
+        let result = Root::parse_with_options(mrml, &opts);
+
+        assert!(result.is_ok());
+        let output = result.unwrap();
+
+        assert_eq!(output.warnings.len(), 1);
+        assert_eq!(output.warnings[0].kind, WarningKind::UnknownElement);
+        assert!(output.warnings[0].to_string().contains("<mj-unknown>"));
+
+        assert_eq!(output.element.0.len(), 1); // Only mjml should be present
+        match &output.element.0[0] {
+            RootChild::Mjml(mjml_node) => {
+                 if let Some(crate::mjml::MjmlChild::MjBody(mj_body)) = &mjml_node.children.get(0) {
+                    if let Some(crate::mj_body::MjBodyChild::MjText(mj_text)) = &mj_body.children.get(0) {
+                        assert_eq!(mj_text.content, "Valid Content");
+                    } else {
+                        panic!("Expected MjText");
+                    }
+                } else {
+                    panic!("Expected MjBody");
+                }
+            }
+            _ => panic!("Expected RootChild::Mjml, found {:?}", output.element.0[0]),
+        }
+    }
+
+    #[test]
+    fn should_warn_and_skip_unknown_self_closing_tag() {
+        let mrml = r#"
+            <mj-unknown-self-closing />
+            <mjml>
+                <mj-body>
+                    <mj-text>Another Content</mj-text>
+                </mj-body>
+            </mjml>
+        "#;
+        let opts = ParserOptions::default();
+        let result = Root::parse_with_options(mrml, &opts);
+
+        assert!(result.is_ok());
+        let output = result.unwrap();
+
+        assert_eq!(output.warnings.len(), 1);
+        assert_eq!(output.warnings[0].kind, WarningKind::UnknownElement);
+        assert!(output.warnings[0].to_string().contains("<mj-unknown-self-closing />"));
+
+        assert_eq!(output.element.0.len(), 1); // Only mjml
+        match &output.element.0[0] {
+            RootChild::Mjml(mjml_node) => {
+                // Basic check for MjBody and MjText presence
+                assert!(!mjml_node.children.is_empty());
+            }
+            _ => panic!("Expected RootChild::Mjml"),
+        }
+    }
+
+    #[test]
+    fn should_handle_mixed_valid_and_unknown_tags() {
+        let mrml = r#"
+            <mj-unknown-before />
+            <mjml>
+              <mj-body>
+                <mj-text>Hello</mj-text>
+              </mj-body>
+            </mjml>
+            <mj-unknown-after>
+                <mj-nested />
+            </mj-unknown-after>
+        "#;
+        let opts = ParserOptions::default();
+        let result = Root::parse_with_options(mrml, &opts);
+
+        assert!(result.is_ok());
+        let output = result.unwrap();
+
+        assert_eq!(output.warnings.len(), 2);
+        assert_eq!(output.warnings[0].kind, WarningKind::UnknownElement);
+        assert!(output.warnings[0].to_string().contains("<mj-unknown-before />"));
+        assert_eq!(output.warnings[1].kind, WarningKind::UnknownElement);
+        assert!(output.warnings[1].to_string().contains("<mj-unknown-after>"));
+        
+        assert_eq!(output.element.0.len(), 1); // Only mjml
+        match &output.element.0[0] {
+            RootChild::Mjml(mjml_node) => {
+                if let Some(crate::mjml::MjmlChild::MjBody(mj_body)) = &mjml_node.children.get(0) {
+                    if let Some(crate::mj_body::MjBodyChild::MjText(mj_text)) = &mj_body.children.get(0) {
+                        assert_eq!(mj_text.content, "Hello");
+                    } else {
+                        panic!("Expected MjText");
+                    }
+                } else {
+                    panic!("Expected MjBody");
+                }
+            }
+            _ => panic!("Expected RootChild::Mjml"),
+        }
+    }
+
+    #[test]
+    fn should_still_error_on_malformed_unclosed_tags() {
+        let mrml = r#"
+            <mjml>
+                <mj-body>
+                    <mj-text>Valid</mj-text>
+                </mj-body>
+            </mjml>
+            <mj-unclosed
+        "#;
+        let opts = ParserOptions::default();
+        let result = Root::parse_with_options(mrml, &opts);
+
+        assert!(result.is_err());
+        let error = result.err().unwrap();
+        // Expecting an UnexpectedEofKind or similar, depending on how the parser handles premature EOF.
+        // The exact error might be Error::UnexpectedEofKind or Error::UnexpectedToken if it hits EOF
+        // while expecting more attributes or the end of the tag.
+        match error {
+            crate::prelude::parser::Error::UnexpectedEofKind { kind, .. } => {
+                assert_eq!(kind, "element");
+            }
+            crate::prelude::parser::Error::UnexpectedToken { .. } => {
+                // This could also be a valid outcome if EOF is treated as an unexpected token
+                // when seeking the end of an attribute list or tag.
+            }
+            _ => panic!("Expected UnexpectedEofKind or UnexpectedToken error, got {:?}", error),
+        }
     }
 }
 
@@ -47,9 +304,14 @@ impl crate::prelude::parser::AsyncParseChildren<Vec<RootChild>>
                 MrmlToken::Comment(inner) => {
                     result.push(RootChild::Comment(Comment::from(inner.text.as_str())));
                 }
-                MrmlToken::ElementStart(inner) if inner.local.eq("mjml") => {
-                    let element = self.async_parse(cursor, inner.local).await?;
-                    result.push(RootChild::Mjml(element));
+                MrmlToken::ElementStart(inner) => {
+                    if inner.local.eq("mjml") {
+                        let element = self.async_parse(cursor, inner.local).await?;
+                        result.push(RootChild::Mjml(element));
+                    } else {
+                        cursor.add_warning(WarningKind::UnknownElement, inner.span.into());
+                        skip_element_and_children(cursor)?;
+                    }
                 }
                 other => {
                     return Err(Error::UnexpectedToken {


### PR DESCRIPTION
Previously, the parser would return an `Error::UnexpectedToken` when encountering an unknown XML tag at the root level of an MJML document (i.e., a tag other than `<mjml>` or `<comment>`).

This change modifies the parsing behavior in `mrml-core` to:
1.  Issue a `WarningKind::UnknownElement` when an unknown root-level tag is encountered.
2.  Skip the unknown tag and all its children, allowing parsing of subsequent valid `<mjml>` sections or other elements to continue.
3.  Malformed XML that isn't just an unknown tag (e.g., unclosed tags) will still result in an error.

This makes the parser more resilient to common mistakes or the presence of non-MJML elements at the beginning or end of a document, providing you with warnings instead of hard errors.

The following changes were made:
- Added `WarningKind::UnknownElement` to `packages/mrml-core/src/prelude/parser/output.rs`.
- Modified `parse_children` (and `async_parse_children`) in `packages/mrml-core/src/root/parse.rs` to detect unknown root-level element start tokens, add a warning, and call a new helper function `skip_element_and_children` to consume the unknown element tree.
- Added comprehensive unit tests in `packages/mrml-core/src/root/parse.rs` to verify:
    - Single unknown tags are skipped and warned.
    - Unknown tags with nested children are skipped and warned.
    - Self-closing unknown tags are handled.
    - Documents with mixed valid `<mjml>` and unknown tags are parsed correctly with appropriate warnings.
    - Structurally malformed input (e.g., unclosed tags) still produces errors.