### PR TITLE
doc: fix `result.startswith` in Python usage demo

### DIFF
--- a/packages/mrml-core/readme.md
+++ b/packages/mrml-core/readme.md
@@ -112,14 +112,14 @@ import mrml
 
 # without options
 result = mrml.to_html("<mjml></mjml>")
-assert result.startswith("<!doctype html>")
+assert result.content.startswith("<!doctype html>")
 
 # with options
 parser_options = mrml.ParserOptions(include_loader = mrml.memory_loader({
     'hello-world.mjml': '<mj-text>Hello World!</mj-text>',
 }))
 result = mrml.to_html("<mjml><mj-body><mj-include path=\"hello-world.mjml\" /></mj-body></mjml>", parser_options = parser_options)
-assert result.startswith("<!doctype html>")
+assert result.content.startswith("<!doctype html>")
 ```
 
 # Why?


### PR DESCRIPTION
The old example crashed with:
```
AttributeError: 'builtins.Output' object has no attribute 'startswith'
```