### PR TITLE
fix: add border-collapse:separate and overflow:hidden when border-radius is set on mj-section

### DIFF
--- a/packages/mrml-core/resources/compare/success/mj-section-border-radius.html
+++ b/packages/mrml-core/resources/compare/success/mj-section-border-radius.html
@@ -61,11 +61,11 @@
   <body style="word-spacing:normal;">
     <div lang="und" dir="auto">
       <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-      <div style="margin:0px auto;border-radius:42px;max-width:600px;">
-        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;border-radius:42px;">
+      <div style="margin:0px auto;border-radius:42px;max-width:600px;overflow:hidden;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;border-collapse:separate;">
           <tbody>
             <tr>
-              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+              <td style="border-radius:42px;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
                 <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr></tr></table><![endif]-->
               </td>
             </tr>

--- a/packages/mrml-core/resources/compare/success/mj-wrapper-border.html
+++ b/packages/mrml-core/resources/compare/success/mj-wrapper-border.html
@@ -61,11 +61,11 @@
   <body style="word-spacing:normal;">
     <div lang="und" dir="auto">
       <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-      <div style="margin:0px auto;border-radius:3px;max-width:600px;">
-        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;border-radius:3px;">
+      <div style="margin:0px auto;border-radius:3px;max-width:600px;overflow:hidden;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;border-collapse:separate;">
           <tbody>
             <tr>
-              <td style="border:1px;border-right:2px;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+              <td style="border:1px;border-right:2px;border-radius:3px;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
                 <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:597px;" width="597" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
                 <div style="margin:0px auto;max-width:597px;">
                   <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/packages/mrml-core/src/mj_section/render.rs
+++ b/packages/mrml-core/src/mj_section/render.rs
@@ -268,12 +268,14 @@ pub trait SectionLikeRender<'root>: WithMjSectionBackground<'root> {
         } else {
             self.set_background_style(tag)
         };
+        let has_border_radius = self.attribute_exists("border-radius");
         base.add_style("margin", "0px auto")
             .maybe_add_style("border-radius", self.attribute("border-radius"))
             .maybe_add_style(
                 "max-width",
                 self.container_width().as_ref().map(|item| item.to_string()),
             )
+            .maybe_add_style("overflow", has_border_radius.then_some("hidden"))
     }
 
     fn render_wrap<F>(&self, cursor: &mut RenderCursor, content: F) -> Result<(), Error>
@@ -364,13 +366,14 @@ pub trait SectionLikeRender<'root>: WithMjSectionBackground<'root> {
         'root: 'a,
         'a: 't,
     {
+        let has_border_radius = self.attribute_exists("border-radius");
         let base = if self.is_full_width() {
             tag
         } else {
             self.set_background_style(tag)
         };
         base.add_style("width", "100%")
-            .maybe_add_style("border-radius", self.attribute("border-radius"))
+            .maybe_add_style("border-collapse", has_border_radius.then_some("separate"))
     }
 
     fn set_style_section_td<'a, 't>(&'a self, tag: Tag<'t>) -> Tag<'t>
@@ -383,6 +386,7 @@ pub trait SectionLikeRender<'root>: WithMjSectionBackground<'root> {
             .maybe_add_style("border-left", self.attribute("border-left"))
             .maybe_add_style("border-right", self.attribute("border-right"))
             .maybe_add_style("border-top", self.attribute("border-top"))
+            .maybe_add_style("border-radius", self.attribute("border-radius"))
             .maybe_add_style("direction", self.attribute("direction"))
             .add_style("font-size", "0px")
             .maybe_add_style("padding", self.attribute("padding"))
@@ -456,7 +460,8 @@ pub trait SectionLikeRender<'root>: WithMjSectionBackground<'root> {
         } else {
             tag
         };
-        base.maybe_add_style("border-radius", self.attribute("border-radius"))
+        let has_border_radius = self.attribute_exists("border-radius");
+        base.maybe_add_style("border-collapse", has_border_radius.then_some("separate"))
             .add_style("width", "100%")
     }
 


### PR DESCRIPTION
When border-radius is present, the global CSS reset (border-collapse: collapse) prevents rounded corners from rendering. 

This matches the node mjml behavior by:
- Adding overflow:hidden to the outer div ([mjml-section/src/index.js#L107](https://github.com/mjmlio/mjml/blob/4cb9615c5e48df3bf8d3b01db3df3366161a87fb/packages/mjml-section/src/index.js#L107))
- Using border-collapse:separate on the table instead of border-radius ([mjml-section/src/index.js:84](https://github.com/mjmlio/mjml/blob/4cb9615c5e48df3bf8d3b01db3df3366161a87fb/packages/mjml-section/src/index.js#L84))
- Moving border-radius to the td element ([mjml-section/src/index.js#L92](https://github.com/mjmlio/mjml/blob/4cb9615c5e48df3bf8d3b01db3df3366161a87fb/packages/mjml-section/src/index.js#L92))

Fixes https://github.com/jdrouet/mrml/issues/610