### PR TITLE
fix: use correct Twitter share URL

### DIFF
--- a/packages/mrml-core/src/mj_social_element/network.rs
+++ b/packages/mrml-core/src/mj_social_element/network.rs
@@ -166,7 +166,7 @@ impl SocialNetwork {
             share_url: if noshare {
                 None
             } else {
-                Some("https://twitter.com/home?status=[[URL]]")
+                Some("https://twitter.com/intent/tweet?url=[[URL]]")
             },
             icon: "twitter.png",
         }
@@ -178,7 +178,7 @@ impl SocialNetwork {
             share_url: if noshare {
                 None
             } else {
-                Some("https://twitter.com/home?status=[[URL]]")
+                Some("https://twitter.com/intent/tweet?url=[[URL]]")
             },
             icon: "twitter-x.png",
         }


### PR DESCRIPTION
The twitter and x social networks used the deprecated twitter.com/home?status= endpoint.

Update to use twitter.com/intent/tweet?url= to match the reference MJML JS implementation.