### PR TITLE
fix: move mso-width-percent to style attribute on v:rect

### DIFF
--- a/packages/mrml-core/resources/compare/success/mj-section-full-width-background-url.html
+++ b/packages/mrml-core/resources/compare/success/mj-section-full-width-background-url.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+  <head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a {
+        padding: 0;
+      }
+
+      body {
+        margin: 0;
+        padding: 0;
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+      }
+
+      table,
+      td {
+        border-collapse: collapse;
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+      }
+
+      img {
+        border: 0;
+        height: auto;
+        line-height: 100%;
+        outline: none;
+        text-decoration: none;
+        -ms-interpolation-mode: bicubic;
+      }
+
+      p {
+        display: block;
+        margin: 13px 0;
+      }
+    </style>
+    <!--[if mso]>
+<noscript>
+<xml>
+<o:OfficeDocumentSettings>
+<o:AllowPNG/>
+<o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml>
+</noscript>
+<![endif]-->
+    <!--[if lte mso 11]>
+<style type="text/css">
+.mj-outlook-group-fix { width:100% !important; }
+</style>
+<![endif]-->
+  </head>
+
+  <body style="word-spacing:normal;">
+    <div lang="und" dir="auto">
+      <table align="center" background="https://www.rust-lang.org/static/images/rust-logo-blk.svg" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:url('https://www.rust-lang.org/static/images/rust-logo-blk.svg') center top / contain no-repeat;background-position:center top;background-repeat:no-repeat;background-size:contain;width:100%;">
+        <tbody>
+          <tr>
+            <td>
+              <!--[if mso | IE]><v:rect style="mso-width-percent:1000;" xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false"><v:fill origin="0, -0.5" position="0, -0.5" src="https://www.rust-lang.org/static/images/rust-logo-blk.svg" type="frame" size="1,1" aspect="atmost" /><v:textbox style="mso-fit-shape-to-text:true" inset="0,0,0,0"><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:600px;">
+                <div style="line-height:0;font-size:0;">
+                  <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                    <tbody>
+                      <tr>
+                        <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr></tr></table><![endif]-->
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+              <!--[if mso | IE]></td></tr></table></v:textbox></v:rect><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </body>
+
+</html>

--- a/packages/mrml-core/resources/compare/success/mj-section-full-width-background-url.mjml
+++ b/packages/mrml-core/resources/compare/success/mj-section-full-width-background-url.mjml
@@ -1,0 +1,11 @@
+<mjml>
+  <mj-body>
+    <mj-section
+      full-width="full-width"
+      background-url="https://www.rust-lang.org/static/images/rust-logo-blk.svg"
+      background-size="contain"
+      background-repeat="no-repeat"
+    >
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/packages/mrml-core/src/mj_section/render.rs
+++ b/packages/mrml-core/src/mj_section/render.rs
@@ -226,7 +226,7 @@ pub trait SectionLikeRender<'root>: WithMjSectionBackground<'root> {
     {
         let full_width = self.is_full_width();
         let vrect = Tag::new("v:rect")
-            .maybe_add_attribute(
+            .maybe_add_style(
                 "mso-width-percent",
                 if full_width { Some("1000") } else { None },
             )

--- a/packages/mrml-core/src/mj_section/render.rs
+++ b/packages/mrml-core/src/mj_section/render.rs
@@ -489,6 +489,7 @@ pub trait SectionLikeRender<'root>: WithMjSectionBackground<'root> {
         td.render_open(&mut cursor.buffer)?;
         //
         if self.has_background() {
+            cursor.buffer.start_conditional_tag();
             self.render_with_background(cursor, |cursor| {
                 self.render_wrap(cursor, |cursor| {
                     cursor.buffer.end_conditional_tag();
@@ -497,6 +498,7 @@ pub trait SectionLikeRender<'root>: WithMjSectionBackground<'root> {
                     Ok(())
                 })
             })?;
+            cursor.buffer.end_conditional_tag();
         } else {
             self.render_wrap(cursor, |cursor| {
                 cursor.buffer.end_conditional_tag();
@@ -609,6 +611,10 @@ mod tests {
     crate::should_render!(class, "mj-section-class");
     crate::should_render!(direction, "mj-section-direction");
     crate::should_render!(full_width, "mj-section-full-width");
+    crate::should_render!(
+        full_width_background_url,
+        "mj-section-full-width-background-url"
+    );
     crate::should_render!(padding, "mj-section-padding");
     crate::should_render!(text_align, "mj-section-text-align");
 }


### PR DESCRIPTION
The `mso-width-percent` property was rendered as an HTML attribute on the VML `v:rect` element, but it should be inside the style attribute.