### PR TITLE
fix(mrml-core): preserve VML namespace prefixes in parsed elements

### DIFF
--- a/packages/mrml-core/resources/compare/success/mj-raw-vml-namespace.html
+++ b/packages/mrml-core/resources/compare/success/mj-raw-vml-namespace.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+  <head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a {
+        padding: 0;
+      }
+
+      body {
+        margin: 0;
+        padding: 0;
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+      }
+
+      table,
+      td {
+        border-collapse: collapse;
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+      }
+
+      img {
+        border: 0;
+        height: auto;
+        line-height: 100%;
+        outline: none;
+        text-decoration: none;
+        -ms-interpolation-mode: bicubic;
+      }
+
+      p {
+        display: block;
+        margin: 13px 0;
+      }
+    </style>
+    <!--[if mso]>
+<noscript>
+<xml>
+<o:OfficeDocumentSettings>
+<o:AllowPNG/>
+<o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml>
+</noscript>
+<![endif]-->
+    <!--[if lte mso 11]>
+<style type="text/css">
+.mj-outlook-group-fix { width:100% !important; }
+</style>
+<![endif]-->
+  </head>
+
+  <body style="word-spacing:normal;">
+    <div aria-roledescription="email" role="article" lang="und" dir="auto">
+      <!--[if mso]><v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:600px;height:128px;"><v:fill type="frame" src="https://example.com/image.jpg"></v:fill></v:rect><![endif]-->
+    </div>
+  </body>
+
+</html>

--- a/packages/mrml-core/resources/compare/success/mj-raw-vml-namespace.mjml
+++ b/packages/mrml-core/resources/compare/success/mj-raw-vml-namespace.mjml
@@ -1,0 +1,11 @@
+<mjml>
+  <mj-body>
+    <mj-raw>
+      <!--[if mso]>
+      <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:600px;height:128px;">
+        <v:fill type="frame" src="https://example.com/image.jpg" />
+      </v:rect>
+      <![endif]-->
+    </mj-raw>
+  </mj-body>
+</mjml>

--- a/packages/mrml-core/src/mj_raw/parse.rs
+++ b/packages/mrml-core/src/mj_raw/parse.rs
@@ -5,12 +5,80 @@ use crate::comment::Comment;
 use crate::conditional_comment::ConditionalComment;
 use crate::node::Node;
 use crate::prelude::is_void_element;
-#[cfg(feature = "async")]
-use crate::prelude::parser::{AsyncMrmlParser, AsyncParseChildren, AsyncParseElement};
 use crate::prelude::parser::{
-    Error, MrmlCursor, MrmlParser, MrmlToken, ParseAttributes, ParseChildren, ParseElement,
+    parse_attributes_map, Error, MrmlCursor, MrmlParser, MrmlToken, ParseChildren, ParseElement,
 };
+#[cfg(feature = "async")]
+use crate::prelude::parser::{AsyncMrmlParser, AsyncParseChildren};
 use crate::text::Text;
+
+fn parse_raw_node<'a>(
+    cursor: &mut MrmlCursor<'a>,
+    tag: StrSpan<'a>,
+    qualified_name: String,
+) -> Result<Node<MjRawChild>, Error> {
+    let attributes = parse_attributes_map(cursor)?;
+    let ending = cursor.assert_element_end()?;
+    if ending.empty || is_void_element(tag.as_str()) {
+        return Ok(Node {
+            tag: qualified_name,
+            attributes,
+            children: Vec::new(),
+        });
+    }
+
+    let children = parse_raw_children(cursor)?;
+    cursor.assert_element_close()?;
+
+    Ok(Node {
+        tag: qualified_name,
+        attributes,
+        children,
+    })
+}
+
+fn parse_raw_children(cursor: &mut MrmlCursor<'_>) -> Result<Vec<MjRawChild>, Error> {
+    let mut children = Vec::new();
+    loop {
+        let token = cursor.assert_next()?;
+        match token {
+            MrmlToken::Comment(inner) => {
+                children.push(MjRawChild::Comment(Comment::from(inner.text.as_str())));
+            }
+            MrmlToken::ElementStart(elt) => {
+                let qualified_name = elt.qualified_name();
+                children.push(MjRawChild::Node(parse_raw_node(
+                    cursor,
+                    elt.local,
+                    qualified_name,
+                )?));
+            }
+            MrmlToken::Text(inner) => {
+                children.push(MjRawChild::Text(Text::from(inner.text.as_str())));
+            }
+            MrmlToken::ElementClose(close) => {
+                cursor.rewind(MrmlToken::ElementClose(close));
+                return Ok(children);
+            }
+            MrmlToken::ConditionalCommentStart(start) => {
+                children.push(MjRawChild::ConditionalComment(ConditionalComment::from(
+                    start.span.as_str(),
+                )));
+            }
+            MrmlToken::ConditionalCommentEnd(end) => {
+                children.push(MjRawChild::ConditionalComment(ConditionalComment::from(
+                    end.span.as_str(),
+                )));
+            }
+            other => {
+                return Err(Error::UnexpectedToken {
+                    origin: cursor.origin(),
+                    position: other.span(),
+                });
+            }
+        }
+    }
+}
 
 impl ParseElement<Node<MjRawChild>> for MrmlParser<'_> {
     fn parse<'a>(
@@ -18,94 +86,26 @@ impl ParseElement<Node<MjRawChild>> for MrmlParser<'_> {
         cursor: &mut MrmlCursor<'a>,
         tag: StrSpan<'a>,
     ) -> Result<Node<MjRawChild>, Error> {
-        let attributes = self.parse_attributes(cursor, &tag)?;
-        let ending = cursor.assert_element_end()?;
-        if ending.empty || is_void_element(tag.as_str()) {
-            return Ok(Node {
-                tag: tag.to_string(),
-                attributes,
-                children: Vec::new(),
-            });
-        }
-
-        let children = self.parse_children(cursor)?;
-        cursor.assert_element_close()?;
-
-        Ok(Node {
-            tag: tag.to_string(),
-            attributes,
-            children,
-        })
+        parse_raw_node(cursor, tag, tag.to_string())
     }
 }
 
 #[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl AsyncParseElement<Node<MjRawChild>> for AsyncMrmlParser {
+impl crate::prelude::parser::AsyncParseElement<Node<MjRawChild>> for AsyncMrmlParser {
     async fn async_parse<'a>(
         &self,
         cursor: &mut MrmlCursor<'a>,
         tag: StrSpan<'a>,
     ) -> Result<Node<MjRawChild>, Error> {
-        let attributes = self.parse_attributes(cursor, &tag)?;
-        let ending = cursor.assert_element_end()?;
-        if ending.empty || is_void_element(tag.as_str()) {
-            return Ok(Node {
-                tag: tag.to_string(),
-                attributes,
-                children: Vec::new(),
-            });
-        }
-
-        let children = self.async_parse_children(cursor).await?;
-        cursor.assert_element_close()?;
-
-        Ok(Node {
-            tag: tag.to_string(),
-            attributes,
-            children,
-        })
+        parse_raw_node(cursor, tag, tag.to_string())
     }
 }
 
 impl ParseChildren<Vec<MjRawChild>> for MrmlParser<'_> {
     fn parse_children(&self, cursor: &mut MrmlCursor<'_>) -> Result<Vec<MjRawChild>, Error> {
-        let mut children = Vec::new();
-        loop {
-            let token = cursor.assert_next()?;
-            match token {
-                MrmlToken::Comment(inner) => {
-                    children.push(MjRawChild::Comment(Comment::from(inner.text.as_str())));
-                }
-                MrmlToken::ElementStart(elt) => {
-                    children.push(MjRawChild::Node(self.parse(cursor, elt.local)?));
-                }
-                MrmlToken::Text(inner) => {
-                    children.push(MjRawChild::Text(Text::from(inner.text.as_str())));
-                }
-                MrmlToken::ElementClose(close) => {
-                    cursor.rewind(MrmlToken::ElementClose(close));
-                    return Ok(children);
-                }
-                MrmlToken::ConditionalCommentStart(start) => {
-                    children.push(MjRawChild::ConditionalComment(ConditionalComment::from(
-                        start.span.as_str(),
-                    )));
-                }
-                MrmlToken::ConditionalCommentEnd(end) => {
-                    children.push(MjRawChild::ConditionalComment(ConditionalComment::from(
-                        end.span.as_str(),
-                    )));
-                }
-                other => {
-                    return Err(Error::UnexpectedToken {
-                        origin: cursor.origin(),
-                        position: other.span(),
-                    });
-                }
-            }
-        }
+        parse_raw_children(cursor)
     }
 }
 
@@ -117,41 +117,7 @@ impl AsyncParseChildren<Vec<MjRawChild>> for AsyncMrmlParser {
         &self,
         cursor: &mut MrmlCursor<'a>,
     ) -> Result<Vec<MjRawChild>, Error> {
-        let mut children = Vec::new();
-        loop {
-            let token = cursor.assert_next()?;
-            match token {
-                MrmlToken::Comment(inner) => {
-                    children.push(MjRawChild::Comment(Comment::from(inner.text.as_str())));
-                }
-                MrmlToken::ElementStart(elt) => {
-                    children.push(MjRawChild::Node(self.async_parse(cursor, elt.local).await?));
-                }
-                MrmlToken::Text(inner) => {
-                    children.push(MjRawChild::Text(Text::from(inner.text.as_str())));
-                }
-                MrmlToken::ElementClose(close) => {
-                    cursor.rewind(MrmlToken::ElementClose(close));
-                    return Ok(children);
-                }
-                MrmlToken::ConditionalCommentStart(start) => {
-                    children.push(MjRawChild::ConditionalComment(ConditionalComment::from(
-                        start.span.as_str(),
-                    )));
-                }
-                MrmlToken::ConditionalCommentEnd(end) => {
-                    children.push(MjRawChild::ConditionalComment(ConditionalComment::from(
-                        end.span.as_str(),
-                    )));
-                }
-                other => {
-                    return Err(Error::UnexpectedToken {
-                        origin: cursor.origin(),
-                        position: other.span(),
-                    })
-                }
-            }
-        }
+        parse_raw_children(cursor)
     }
 }
 

--- a/packages/mrml-core/src/mj_raw/render.rs
+++ b/packages/mrml-core/src/mj_raw/render.rs
@@ -61,4 +61,5 @@ mod tests {
     crate::should_render!(basic, "mj-raw");
     crate::should_render!(in_head, "mj-raw-head");
     crate::should_render!(conditional_comment, "mj-raw-conditional-comment");
+    crate::should_render!(vml_namespace, "mj-raw-vml-namespace");
 }

--- a/packages/mrml-core/src/prelude/parser/mod.rs
+++ b/packages/mrml-core/src/prelude/parser/mod.rs
@@ -331,7 +331,7 @@ pub(crate) fn parse_attributes_map(
     let mut result = Map::new();
     while let Some(attr) = cursor.next_attribute()? {
         result.insert(
-            attr.local.to_string(),
+            attr.qualified_name(),
             attr.value.map(|inner| inner.to_string()),
         );
     }

--- a/packages/mrml-core/src/prelude/parser/token.rs
+++ b/packages/mrml-core/src/prelude/parser/token.rs
@@ -145,11 +145,20 @@ impl MrmlToken<'_> {
 
 #[derive(Debug)]
 pub(crate) struct Attribute<'a> {
-    #[allow(unused)]
     pub prefix: StrSpan<'a>,
     pub local: StrSpan<'a>,
     pub value: Option<StrSpan<'a>>,
     pub span: StrSpan<'a>,
+}
+
+impl Attribute<'_> {
+    pub fn qualified_name(&self) -> String {
+        if self.prefix.is_empty() {
+            self.local.to_string()
+        } else {
+            format!("{}:{}", self.prefix, self.local)
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -178,10 +187,19 @@ pub(crate) struct ElementClose<'a> {
 
 #[derive(Debug)]
 pub(crate) struct ElementStart<'a> {
-    #[allow(unused)]
     pub prefix: StrSpan<'a>,
     pub local: StrSpan<'a>,
     pub span: StrSpan<'a>,
+}
+
+impl ElementStart<'_> {
+    pub fn qualified_name(&self) -> String {
+        if self.prefix.is_empty() {
+            self.local.to_string()
+        } else {
+            format!("{}:{}", self.prefix, self.local)
+        }
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Closes #606