### PR TITLE
fix(mrml-core): propagate container width to mj-hero children

### DIFF
--- a/packages/mrml-core/resources/compare/success/mj-hero-divider.html
+++ b/packages/mrml-core/resources/compare/success/mj-hero-divider.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+  <head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a {
+        padding: 0;
+      }
+
+      body {
+        margin: 0;
+        padding: 0;
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+      }
+
+      table,
+      td {
+        border-collapse: collapse;
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+      }
+
+      img {
+        border: 0;
+        height: auto;
+        line-height: 100%;
+        outline: none;
+        text-decoration: none;
+        -ms-interpolation-mode: bicubic;
+      }
+
+      p {
+        display: block;
+        margin: 13px 0;
+      }
+    </style>
+    <!--[if mso]>
+<noscript>
+<xml>
+<o:OfficeDocumentSettings>
+<o:AllowPNG/>
+<o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml>
+</noscript>
+<![endif]-->
+    <!--[if lte mso 11]>
+<style type="text/css">
+.mj-outlook-group-fix { width:100% !important; }
+</style>
+<![endif]-->
+  </head>
+
+  <body style="word-spacing:normal;">
+    <div aria-roledescription="email" role="article" lang="und" dir="auto">
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0;font-size:0;mso-line-height-rule:exactly;"><v:image style="border:0;mso-position-horizontal:center;position:absolute;top:0;width:600px;z-index:-3;" xmlns:v="urn:schemas-microsoft-com:vml" /><![endif]-->
+      <div style="margin:0 auto;max-width:600px;">
+        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr style="vertical-align:top;">
+              <td style="background:#ffffff;background-position:center center;background-repeat:no-repeat;padding:0px;vertical-align:top;height:0px;" height="0">
+                <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" style="width:600px;" width="600" ><tr><td ><![endif]-->
+                <div class="mj-hero-content" style="margin:0px auto;">
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;margin:0px;">
+                    <tbody>
+                      <tr>
+                        <td>
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;margin:0px;">
+                            <tbody>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                  <p style="border-top:solid 4px #000000;font-size:1px;margin:0px auto;width:100%;">
+                                  </p>
+                                  <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 4px #000000;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    </div>
+  </body>
+
+</html>

--- a/packages/mrml-core/resources/compare/success/mj-hero-divider.mjml
+++ b/packages/mrml-core/resources/compare/success/mj-hero-divider.mjml
@@ -1,0 +1,7 @@
+<mjml>
+  <mj-body>
+    <mj-hero>
+      <mj-divider />
+    </mj-hero>
+  </mj-body>
+</mjml>

--- a/packages/mrml-core/src/mj_hero/render.rs
+++ b/packages/mrml-core/src/mj_hero/render.rs
@@ -142,6 +142,7 @@ impl<'root> Renderer<'root, MjHero, ()> {
             renderer.set_index(index);
             renderer.set_siblings(siblings);
             renderer.set_raw_siblings(raw_siblings);
+            renderer.set_container_width(self.container_width);
             if child.is_raw() {
                 renderer.render(cursor)?;
             } else {
@@ -382,4 +383,5 @@ mod tests {
     crate::should_render!(mode, "mj-hero-mode");
     crate::should_render!(vertical_align, "mj-hero-vertical-align");
     crate::should_render!(width, "mj-hero-width");
+    crate::should_render!(divider, "mj-hero-divider");
 }


### PR DESCRIPTION
In `mj_hero/render.rs:141`, child renderers were created without calling `set_container_width()`. This meant children like `mj-divider` had `container_width =
  None,` causing the Outlook conditional width to be missing (and on older versions, a panic from `unwrap()` on `None`).

Closes #500