### PR TITLE
fix(mrml-core): propagate section inner width to column children

### DIFF
--- a/packages/mrml-core/resources/compare/success/mj-wrapper-full-width-section-background.html
+++ b/packages/mrml-core/resources/compare/success/mj-wrapper-full-width-section-background.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+  <head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a {
+        padding: 0;
+      }
+
+      body {
+        margin: 0;
+        padding: 0;
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+      }
+
+      table,
+      td {
+        border-collapse: collapse;
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+      }
+
+      img {
+        border: 0;
+        height: auto;
+        line-height: 100%;
+        outline: none;
+        text-decoration: none;
+        -ms-interpolation-mode: bicubic;
+      }
+
+      p {
+        display: block;
+        margin: 13px 0;
+      }
+    </style>
+    <!--[if mso]>
+<noscript>
+<xml>
+<o:OfficeDocumentSettings>
+<o:AllowPNG/>
+<o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml>
+</noscript>
+<![endif]-->
+    <!--[if lte mso 11]>
+<style type="text/css">
+.mj-outlook-group-fix { width:100% !important; }
+</style>
+<![endif]-->
+    <!--[if !mso]><!-->
+    <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+    <style type="text/css">
+      @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+    </style>
+    <!--<![endif]-->
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 {
+          width: 100% !important;
+          max-width: 100%;
+        }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+    </style>
+  </head>
+
+  <body style="word-spacing:normal;">
+    <div aria-roledescription="email" role="article" lang="und" dir="auto">
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+      <div style="margin:0px auto;max-width:600px;">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><![endif]-->
+                <table align="center" background="https://example.com/image.jpg" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:url('https://example.com/image.jpg') center top / cover no-repeat;background-position:center top;background-repeat:no-repeat;background-size:cover;width:100%;">
+                  <tbody>
+                    <tr>
+                      <td>
+                        <!--[if mso | IE]><v:rect style="mso-width-percent:1000;" xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false"><v:fill origin="0, -0.5" position="0, -0.5" src="https://example.com/image.jpg" type="frame" size="1,1" aspect="atleast" /><v:textbox style="mso-fit-shape-to-text:true" inset="0,0,0,0"><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+                        <div style="margin:0px auto;max-width:600px;">
+                          <div style="line-height:0;font-size:0;">
+                            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                              <tbody>
+                                <tr>
+                                  <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                                    <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+                                    <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                                      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                                        <tbody>
+                                          <tr>
+                                            <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                              <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Hero section</div>
+                                            </td>
+                                          </tr>
+                                        </tbody>
+                                      </table>
+                                    </div>
+                                    <!--[if mso | IE]></td></tr></table><![endif]-->
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </div>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table></v:textbox></v:rect><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                <!--[if mso | IE]></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+                <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:600px;">
+                  <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+                    <tbody>
+                      <tr>
+                        <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+                          <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                              <tbody>
+                                <tr>
+                                  <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                    <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Regular section</div>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </div>
+                          <!--[if mso | IE]></td></tr></table><![endif]-->
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    </div>
+  </body>
+
+</html>

--- a/packages/mrml-core/resources/compare/success/mj-wrapper-full-width-section-background.mjml
+++ b/packages/mrml-core/resources/compare/success/mj-wrapper-full-width-section-background.mjml
@@ -1,0 +1,16 @@
+<mjml>
+  <mj-body>
+    <mj-wrapper>
+      <mj-section full-width="full-width" background-url="https://example.com/image.jpg" background-size="cover" background-repeat="no-repeat">
+        <mj-column>
+          <mj-text>Hero section</mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-section background-color="#ffffff">
+        <mj-column>
+          <mj-text>Regular section</mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+  </mj-body>
+</mjml>

--- a/packages/mrml-core/src/mj_section/render.rs
+++ b/packages/mrml-core/src/mj_section/render.rs
@@ -220,6 +220,14 @@ pub trait SectionLikeRender<'root>: WithMjSectionBackground<'root> {
         self.attribute_exists("full-width")
     }
 
+    fn current_width(&self) -> Option<Pixel> {
+        self.container_width().as_ref().map(|width| {
+            let hborder = self.get_border_horizontal();
+            let hpadding = self.get_padding_horizontal();
+            Pixel::new(width.value() - hborder.value() - hpadding.value())
+        })
+    }
+
     fn render_with_background<F>(&self, cursor: &mut RenderCursor, content: F) -> Result<(), Error>
     where
         F: Fn(&mut RenderCursor) -> Result<(), Error>,
@@ -328,6 +336,7 @@ pub trait SectionLikeRender<'root>: WithMjSectionBackground<'root> {
     fn render_wrapped_children(&self, cursor: &mut RenderCursor) -> Result<(), Error> {
         let siblings = self.get_siblings();
         let raw_siblings = self.get_raw_siblings();
+        let current_width = self.current_width();
         let tr = Tag::tr();
 
         tr.render_open(&mut cursor.buffer)?;
@@ -336,7 +345,7 @@ pub trait SectionLikeRender<'root>: WithMjSectionBackground<'root> {
             let mut renderer = child.renderer(self.context());
             renderer.set_siblings(siblings);
             renderer.set_raw_siblings(raw_siblings);
-            renderer.set_container_width(*self.container_width());
+            renderer.set_container_width(current_width);
             if child.is_raw() {
                 renderer.render(cursor)?;
             } else {

--- a/packages/mrml-core/src/mj_wrapper/render.rs
+++ b/packages/mrml-core/src/mj_wrapper/render.rs
@@ -114,4 +114,8 @@ mod tests {
     crate::should_render!(border, "mj-wrapper-border");
     crate::should_render!(other, "mj-wrapper-other");
     crate::should_render!(padding, "mj-wrapper-padding");
+    crate::should_render!(
+        full_width_section_background,
+        "mj-wrapper-full-width-section-background"
+    );
 }

--- a/packages/mrml-core/src/prelude/render/mod.rs
+++ b/packages/mrml-core/src/prelude/render/mod.rs
@@ -125,12 +125,14 @@ pub(crate) trait Render<'root> {
     }
 
     fn get_border_left(&self) -> Option<Pixel> {
-        self.attribute_as_pixel("border-left")
+        self.attribute("border-left")
+            .and_then(Pixel::from_border)
             .or_else(|| self.attribute("border").and_then(Pixel::from_border))
     }
 
     fn get_border_right(&self) -> Option<Pixel> {
-        self.attribute_as_pixel("border-right")
+        self.attribute("border-right")
+            .and_then(Pixel::from_border)
             .or_else(|| self.attribute("border").and_then(Pixel::from_border))
     }
 


### PR DESCRIPTION
This came from 2 issues:
- the section component didn't substract its own padding/border when calculating child width
- the border shorthand parsing failed for side-specific borders

Closes #574