### PR TITLE
fix(mrml-core): parse quoted names in font-family values

### DIFF
--- a/packages/mrml-core/src/prelude/render/header.rs
+++ b/packages/mrml-core/src/prelude/render/header.rs
@@ -5,6 +5,90 @@ use crate::helper::size::{Pixel, Size};
 use crate::mj_head::MjHead;
 use crate::prelude::hash::{Map, Set};
 
+pub(crate) fn parse_font_families(value: &str) -> Vec<&str> {
+    let mut in_quote: Option<char> = None;
+    value
+        .split(|c: char| match (in_quote, c) {
+            (None, ',') => true,
+            (None, '\'' | '"') => {
+                in_quote = Some(c);
+                false
+            }
+            (Some(q), c) if q == c => {
+                in_quote = None;
+                false
+            }
+            _ => false,
+        })
+        .map(str::trim)
+        .map(unwrap_quotes)
+        .filter(|token| !token.is_empty())
+        .collect()
+}
+
+fn unwrap_quotes(token: &str) -> &str {
+    for quote in ['\'', '"'] {
+        if let Some(inner) = token
+            .strip_prefix(quote)
+            .and_then(|s| s.strip_suffix(quote))
+        {
+            return inner;
+        }
+    }
+    token
+}
+
+#[cfg(test)]
+mod parse_font_families_tests {
+    use super::parse_font_families;
+
+    #[test]
+    fn unquoted_comma_separated_list() {
+        assert_eq!(
+            parse_font_families("Roboto, Arial, sans-serif"),
+            vec!["Roboto", "Arial", "sans-serif"]
+        );
+    }
+
+    #[test]
+    fn single_quoted_name_containing_comma_is_one_token() {
+        assert_eq!(
+            parse_font_families("'Open, Sans', Ubuntu, sans-serif"),
+            vec!["Open, Sans", "Ubuntu", "sans-serif"]
+        );
+    }
+
+    #[test]
+    fn double_quoted_name_containing_comma_is_one_token() {
+        assert_eq!(
+            parse_font_families("\"Open, Sans\", Ubuntu"),
+            vec!["Open, Sans", "Ubuntu"]
+        );
+    }
+
+    #[test]
+    fn single_quotes_are_stripped_from_names_without_commas() {
+        assert_eq!(
+            parse_font_families("'Source Sans 3', Helvetica, Arial, sans-serif"),
+            vec!["Source Sans 3", "Helvetica", "Arial", "sans-serif"]
+        );
+    }
+
+    #[test]
+    fn empty_tokens_are_filtered() {
+        assert_eq!(
+            parse_font_families("Roboto, , Arial"),
+            vec!["Roboto", "Arial"]
+        );
+    }
+
+    #[test]
+    fn empty_input_yields_no_tokens() {
+        assert!(parse_font_families("").is_empty());
+        assert!(parse_font_families("   ").is_empty());
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct VariableHeader {
     used_font_families: Set<String>,
@@ -36,12 +120,7 @@ impl VariableHeader {
     }
 
     pub fn add_font_families<T: AsRef<str>>(&mut self, value: T) {
-        for name in value
-            .as_ref()
-            .split(',')
-            .map(|item| item.trim())
-            .filter(|item| !item.is_empty())
-        {
+        for name in parse_font_families(value.as_ref()) {
             self.add_used_font_family(name);
         }
     }

--- a/packages/mrml-core/src/prelude/render/header.rs
+++ b/packages/mrml-core/src/prelude/render/header.rs
@@ -5,10 +5,10 @@ use crate::helper::size::{Pixel, Size};
 use crate::mj_head::MjHead;
 use crate::prelude::hash::{Map, Set};
 
-pub(crate) fn parse_font_families(value: &str) -> Vec<&str> {
+pub(crate) fn parse_font_families(value: &str) -> impl Iterator<Item = &str> + '_ {
     let mut in_quote: Option<char> = None;
     value
-        .split(|c: char| match (in_quote, c) {
+        .split(move |c: char| match (in_quote, c) {
             (None, ',') => true,
             (None, '\'' | '"') => {
                 in_quote = Some(c);
@@ -23,7 +23,6 @@ pub(crate) fn parse_font_families(value: &str) -> Vec<&str> {
         .map(str::trim)
         .map(unwrap_quotes)
         .filter(|token| !token.is_empty())
-        .collect()
 }
 
 fn unwrap_quotes(token: &str) -> &str {
@@ -45,7 +44,7 @@ mod parse_font_families_tests {
     #[test]
     fn unquoted_comma_separated_list() {
         assert_eq!(
-            parse_font_families("Roboto, Arial, sans-serif"),
+            parse_font_families("Roboto, Arial, sans-serif").collect::<Vec<_>>(),
             vec!["Roboto", "Arial", "sans-serif"]
         );
     }
@@ -53,7 +52,7 @@ mod parse_font_families_tests {
     #[test]
     fn single_quoted_name_containing_comma_is_one_token() {
         assert_eq!(
-            parse_font_families("'Open, Sans', Ubuntu, sans-serif"),
+            parse_font_families("'Open, Sans', Ubuntu, sans-serif").collect::<Vec<_>>(),
             vec!["Open, Sans", "Ubuntu", "sans-serif"]
         );
     }
@@ -61,7 +60,7 @@ mod parse_font_families_tests {
     #[test]
     fn double_quoted_name_containing_comma_is_one_token() {
         assert_eq!(
-            parse_font_families("\"Open, Sans\", Ubuntu"),
+            parse_font_families("\"Open, Sans\", Ubuntu").collect::<Vec<_>>(),
             vec!["Open, Sans", "Ubuntu"]
         );
     }
@@ -69,7 +68,8 @@ mod parse_font_families_tests {
     #[test]
     fn single_quotes_are_stripped_from_names_without_commas() {
         assert_eq!(
-            parse_font_families("'Source Sans 3', Helvetica, Arial, sans-serif"),
+            parse_font_families("'Source Sans 3', Helvetica, Arial, sans-serif")
+                .collect::<Vec<_>>(),
             vec!["Source Sans 3", "Helvetica", "Arial", "sans-serif"]
         );
     }
@@ -77,15 +77,15 @@ mod parse_font_families_tests {
     #[test]
     fn empty_tokens_are_filtered() {
         assert_eq!(
-            parse_font_families("Roboto, , Arial"),
+            parse_font_families("Roboto, , Arial").collect::<Vec<_>>(),
             vec!["Roboto", "Arial"]
         );
     }
 
     #[test]
     fn empty_input_yields_no_tokens() {
-        assert!(parse_font_families("").is_empty());
-        assert!(parse_font_families("   ").is_empty());
+        assert!(parse_font_families("").next().is_none());
+        assert!(parse_font_families("   ").next().is_none());
     }
 }
 

--- a/packages/mrml-core/tests/mj-font.rs
+++ b/packages/mrml-core/tests/mj-font.rs
@@ -21,3 +21,27 @@ fn should_have_a_single_roboto_font_imported() {
     let rendered = parsed.element.render(&RenderOptions::default()).unwrap();
     assert!(!rendered.contains("Roboto:300,400,500,700"));
 }
+
+#[test]
+fn quoted_font_family_value_still_imports_matching_font() {
+    let parsed = mrml::parse(
+        r#"<mjml>
+  <mj-head>
+    <mj-font name="Source Sans 3" href="https://fonts.googleapis.com/css?family=Source+Sans+3" />
+    <mj-attributes>
+      <mj-all font-family="'Source Sans 3', Helvetica, Arial, sans-serif" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-text>Hello</mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>"#,
+    )
+    .unwrap();
+    let rendered = parsed.element.render(&RenderOptions::default()).unwrap();
+    assert!(rendered.contains("fonts.googleapis.com/css?family=Source+Sans+3"));
+}


### PR DESCRIPTION
`add_font_families` previously only split font-family attribute values on commas, so a value like `'Source Sans 3', Helvetica, Arial` was tokenised as `'Source Sans 3'` (with the surrounding single quotes). The quoted token then failed lookup against the registered `mj-font name="Source Sans 3"` and the corresponding Google Fonts `<link>` was never emitted in `<head>`.

Replace the naive split with a small `parse_font_families` helper that splits and strips a single matching pair of `'` or `"` delimiters. Embedded commas inside `'One, Two'` are preserved as part of the family name.

<hr>

@jdrouet the current test case felt right but let me know if you prefer a comparison test according to the contributing guidelines.