### PR TITLE
docs: add zed-mjml to the list of what is using it

### DIFF
--- a/packages/mrml-core/readme.md
+++ b/packages/mrml-core/readme.md
@@ -163,6 +163,7 @@ With the same Linux amd64 machine, to render the amario template
 - [wagtail-newsletter](https://github.com/wagtail/wagtail-newsletter) - Wagtail extension
 - [intellij-mjml-support](https://github.com/timo-reymann/intellij-mjml-support) - MJML support for the IntelliJ Platform
 - [mjml-php](https://github.com/alekitto/mjml-php) - PHP extension
+- [zed-mjml](https://github.com/pataruco/zed-mjml) - MJML syntax support for Zed
 
 <i>If you are using MRML and want to be added to this list, don't hesitate to create an issue or open a pull request.</i>
 


### PR DESCRIPTION
Thanks very much for your library.

I created [zed-mjml](https://github.com/pataruco/zed-mjml), a Zed extension that provides LSP, Grammar and Syntax support. It was integrated within the Zed ecosystem last week https://github.com/zed-industries/extensions/pull/5140

This is my token of appreaciation