### PR TITLE
fix: also consider carriage return when skipping empty tokens

### DIFF
--- a/packages/mrml-core/src/mjml/parse.rs
+++ b/packages/mrml-core/src/mjml/parse.rs
@@ -409,4 +409,19 @@ mod tests {
         let template = "<mjml><div /></mjml>";
         let _ = Mjml::parse(template).unwrap();
     }
+
+    #[test]
+    fn should_parse_with_crlf_line_endings_and_void_element_sync() {
+        let template = "<mjml><mj-body><mj-section><mj-column><mj-text><br></mj-text></mj-column></mj-section></mj-body></mjml>\r\n";
+        let output = Mjml::parse(template).unwrap();
+        assert!(output.element.children.body.is_some());
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn should_parse_with_crlf_line_endings_and_void_element_async() {
+        let template = "<mjml><mj-body><mj-section><mj-column><mj-text><br></mj-text></mj-column></mj-section></mj-body></mjml>\r\n";
+        let output = Mjml::async_parse(template).await.unwrap();
+        assert!(output.element.children.body.is_some());
+    }
 }

--- a/packages/mrml-core/src/prelude/parser/token.rs
+++ b/packages/mrml-core/src/prelude/parser/token.rs
@@ -226,7 +226,7 @@ impl<'a> super::MrmlCursor<'a> {
             })
             .and_then(|token| match token {
                 Ok(MrmlToken::Text(inner))
-                    if inner.text.starts_with('\n') && inner.text.trim().is_empty() =>
+                    if inner.text.starts_with(['\n', '\r']) && inner.text.trim().is_empty() =>
                 {
                     self.read_next_token()
                 }

--- a/packages/mrml-core/src/prelude/parser/token.rs
+++ b/packages/mrml-core/src/prelude/parser/token.rs
@@ -327,3 +327,47 @@ impl<'a> super::MrmlCursor<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{MrmlToken, Text};
+    use crate::prelude::parser::MrmlCursor;
+
+    fn assert_element_start<'a>(
+        token: Option<Result<MrmlToken<'a>, super::super::Error>>,
+        name: &str,
+    ) {
+        match token {
+            Some(Ok(MrmlToken::ElementStart(inner))) => assert_eq!(inner.local.as_str(), name),
+            other => panic!("expected element start `{name}`, got {other:?}"),
+        }
+    }
+
+    // Whitespace-only text tokens leading with `\r` are emitted by the tokenizer
+    // for CRLF line endings and must be skipped just like `\n` ones. See issue #654.
+    #[test]
+    fn should_skip_whitespace_text_starting_with_carriage_return() {
+        let mut cursor = MrmlCursor::new("<a>\r\n<b></b></a>");
+        assert_element_start(cursor.next_token(), "a");
+        assert!(matches!(
+            cursor.next_token(),
+            Some(Ok(MrmlToken::ElementEnd(_)))
+        ));
+        // the standalone "\r\n" text token in between must be skipped
+        assert_element_start(cursor.next_token(), "b");
+    }
+
+    #[test]
+    fn should_keep_text_with_non_whitespace_content() {
+        let mut cursor = MrmlCursor::new("<a>\r\nhello</a>");
+        assert_element_start(cursor.next_token(), "a");
+        assert!(matches!(
+            cursor.next_token(),
+            Some(Ok(MrmlToken::ElementEnd(_)))
+        ));
+        assert!(matches!(
+            cursor.next_token(),
+            Some(Ok(MrmlToken::Text(Text { text }))) if text.as_str() == "\r\nhello"
+        ));
+    }
+}

--- a/packages/mrml-core/src/prelude/parser/token.rs
+++ b/packages/mrml-core/src/prelude/parser/token.rs
@@ -344,7 +344,8 @@ mod tests {
     }
 
     // Whitespace-only text tokens leading with `\r` are emitted by the tokenizer
-    // for CRLF line endings and must be skipped just like `\n` ones. See issue #654.
+    // for CRLF line endings and must be skipped just like `\n` ones. See issue
+    // #654.
     #[test]
     fn should_skip_whitespace_text_starting_with_carriage_return() {
         let mut cursor = MrmlCursor::new("<a>\r\n<b></b></a>");


### PR DESCRIPTION
Replaces #655 and closes #654 