### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Bumps `crossbeam-epoch` from 0.9.18 to 0.9.20 in `Cargo.lock`.

## Why

The `security audit` job is failing on **RUSTSEC-2026-0204** — *invalid pointer dereference in the `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid*. Patched in `>= 0.9.20`.

`crossbeam-epoch` is pulled in transitively via `crossbeam-deque`, so the advisory fails the audit job on `main` and on every dependency PR — that is what is currently blocking #659, which is otherwise unrelated to this crate.

Lockfile-only change: `cargo update -p crossbeam-epoch`.

## Verification

- `cargo build --workspace --all-features` — passes
- `cargo test --workspace --all-features` — passes