### PR TITLE
ci: drop registry-url from the demo workflows

### DIFF
--- a/.github/workflows/example-demo-test.yml
+++ b/.github/workflows/example-demo-test.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: latest
-          registry-url: "https://registry.npmjs.org"
       - name: install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - uses: actions/cache@v6

--- a/.github/workflows/example-demo.yml
+++ b/.github/workflows/example-demo.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: latest
-          registry-url: "https://registry.npmjs.org"
       - name: install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - uses: actions/cache@v6


### PR DESCRIPTION
Removes `registry-url` from `example-demo.yml` and `example-demo-test.yml`.

## Why

Neither demo workflow publishes to npm, but `registry-url` makes `setup-node` write an `.npmrc` containing a `${NODE_AUTH_TOKEN}` placeholder.

`setup-node` v6 also exported a dummy `NODE_AUTH_TOKEN`, so the placeholder always resolved. v7 removed that dummy export ([actions/setup-node#1558](https://github.com/actions/setup-node/pull/1558)), and yarn 1 hard-fails on an unresolvable env reference:

```
$ yarn link
yarn link v1.22.22
error Error: Failed to replace env in config: ${NODE_AUTH_TOKEN}
    at envReplace (/usr/local/lib/node_modules/yarn/lib/cli.js:95448:16)
```

That is what fails the `test building demo` job on #658. Dropping `registry-url` stops the `.npmrc` from being written at all, which unblocks the `setup-node` v7 bump — and is the right config for these workflows regardless of the action version.

`mrml-wasm-release.yml` keeps its `registry-url`: it does publish, via `npm publish --provenance` with OIDC trusted publishing, and npm does not choke on the unresolved placeholder the way yarn 1 does.
