### PR TITLE
style: rewrap comments for current nightly rustfmt

### DIFF
--- a/packages/mrml-core/lib/html-compare/src/lib.rs
+++ b/packages/mrml-core/lib/html-compare/src/lib.rs
@@ -171,7 +171,8 @@ fn compare_attributes<'a>(
     let exp_keys = exp_attrs
         .iter()
         .filter(|attr| {
-            // if attribute is `class` or `style`, and the value is empty, we can ignore it
+            // if attribute is `class` or `style`, and the value is empty, we
+            // can ignore it
             if ["alt", "class", "style"].contains(&attr.local.as_str()) {
                 attr.value.is_some_and(|v| !v.is_empty())
             } else {

--- a/packages/mrml-core/src/prelude/parser/token.rs
+++ b/packages/mrml-core/src/prelude/parser/token.rs
@@ -343,9 +343,9 @@ mod tests {
         }
     }
 
-    // Whitespace-only text tokens leading with `\r` are emitted by the tokenizer
-    // for CRLF line endings and must be skipped just like `\n` ones. See issue
-    // #654.
+    // Whitespace-only text tokens leading with `\r` are emitted by the
+    // tokenizer for CRLF line endings and must be skipped just like `\n`
+    // ones. See issue #654.
     #[test]
     fn should_skip_whitespace_text_starting_with_carriage_return() {
         let mut cursor = MrmlCursor::new("<a>\r\n<b></b></a>");


### PR DESCRIPTION
`cargo fmt --all --check` in the `code-checking` workflow runs on floating nightly, whose comment wrapping now differs from the committed formatting. The job failed on every open pull request as a result.

Reformatted the two affected comments. `cargo clippy --all-targets --all-features --tests --workspace` on nightly is clean apart from pre-existing unused-dependency warnings.

Note: nightly stays unpinned, so this can recur on a future rustfmt change.