### PR TITLE
build(deps): remove unused itertools dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,15 +1249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,7 +1531,6 @@ dependencies = [
  "html-compare",
  "htmlparser",
  "indexmap",
- "itertools 0.14.0",
  "mockito",
  "reqwest",
  "rustc-hash",

--- a/packages/mrml-core/Cargo.toml
+++ b/packages/mrml-core/Cargo.toml
@@ -54,7 +54,6 @@ ureq = { version = "3.0", optional = true }
 url = { version = "2.5", optional = true }
 
 # macros
-itertools = { version = "0.14" }
 enum_dispatch = { version = "0.3", optional = true }
 enum-as-inner = { version = "0.7", optional = true }
 


### PR DESCRIPTION
`itertools` is declared as a non-optional dependency of `mrml-core`, but nothing in the workspace references it — `itertools` and `Itertools` have no match in any `.rs` file. It has been compiled into every build of the crate for nothing.

Removing it, and regenerating the lockfile. No source change.

`criterion` still pulls in `itertools` 0.13 transitively as a dev-dependency; that one is untouched.

Checked with `cargo +nightly fmt --all --check`, `cargo check`/`clippy --all-features --all-targets --workspace` under `-Dwarnings`, and `cargo test --workspace --all-features`.