### PR TITLE
fix: remove deleted macro crates from the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,8 @@ WORKDIR /code
 RUN cargo init --bin --name axum-mrml /code/examples/axum \
   && cargo init --bin --name mrml-cli /code/packages/mrml-cli \
   && cargo init --lib --name mrml /code/packages/mrml-core \
-  && cargo init --lib --name mrml-common-macros /code/packages/mrml-core/lib/common-macros \
   && cargo init --lib --name css-compare /code/packages/mrml-core/lib/css-compare \
   && cargo init --lib --name html-compare /code/packages/mrml-core/lib/html-compare \
-  && cargo init --lib --name mrml-json-macros /code/packages/mrml-core/lib/mrml-json-macros \
-  && cargo init --lib --name mrml-macros /code/packages/mrml-core/lib/mrml-macros \
-  && cargo init --lib --name mrml-print-macros /code/packages/mrml-core/lib/mrml-print-macros \
   && cargo init --lib --name mrml-python /code/packages/mrml-python \
   && cargo init --lib --name mrml-warm /code/packages/mrml-wasm
 COPY Cargo.lock /code/Cargo.lock
@@ -19,12 +15,8 @@ COPY Cargo.toml /code/Cargo.toml
 COPY examples/axum/Cargo.toml /code/examples/axum/Cargo.toml
 COPY packages/mrml-cli/Cargo.toml /code/packages/mrml-cli/Cargo.toml
 COPY packages/mrml-core/Cargo.toml /code/packages/mrml-core/Cargo.toml
-COPY packages/mrml-core/lib/common-macros/Cargo.toml /code/packages/mrml-core/lib/common-macros/Cargo.toml
 COPY packages/mrml-core/lib/css-compare/Cargo.toml /code/packages/mrml-core/lib/css-compare/Cargo.toml
 COPY packages/mrml-core/lib/html-compare/Cargo.toml /code/packages/mrml-core/lib/html-compare/Cargo.toml
-COPY packages/mrml-core/lib/mrml-json-macros/Cargo.toml /code/packages/mrml-core/lib/mrml-json-macros/Cargo.toml
-COPY packages/mrml-core/lib/mrml-macros/Cargo.toml /code/packages/mrml-core/lib/mrml-macros/Cargo.toml
-COPY packages/mrml-core/lib/mrml-print-macros/Cargo.toml /code/packages/mrml-core/lib/mrml-print-macros/Cargo.toml
 COPY packages/mrml-python/Cargo.toml /code/packages/mrml-python/Cargo.toml
 COPY packages/mrml-wasm/Cargo.toml /code/packages/mrml-wasm/Cargo.toml
 


### PR DESCRIPTION
The vendor stage still stubs and COPYs four crates that were removed from the repo a long time ago:

- `packages/mrml-core/lib/common-macros`
- `packages/mrml-core/lib/mrml-json-macros`
- `packages/mrml-core/lib/mrml-macros`
- `packages/mrml-core/lib/mrml-print-macros`

`packages/mrml-core/lib/` only holds `css-compare` and `html-compare` now. A `COPY` of a missing path is a hard error, so the image could not be built at all — I confirmed the failure before the change and `docker build --target cli` after it, which now completes and tags the image.

The `cargo init` list matches the workspace members again. Only deletions, nothing else in the file touched.

Unrelated and left alone: the stub for `packages/mrml-wasm` is created with `--name mrml-warm`. It is harmless, since the real manifest is copied over the stub immediately after, but it is a typo if you want it gone in a separate change.