### PR TITLE
refactor(mrml-cli): read input files with fs::read_to_string

### DIFF
--- a/packages/mrml-cli/src/main.rs
+++ b/packages/mrml-cli/src/main.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::error::Error;
-use std::fs::File;
 use std::io::prelude::*;
 use std::iter::FromIterator;
 use std::path::PathBuf;
@@ -52,12 +51,8 @@ struct Options {
 impl Options {
     fn read_file(&self, filename: &str) -> Result<String, String> {
         log::debug!("reading from file {filename}");
-        let mut file =
-            File::open(filename).map_err(|err| format!("couldn't open {filename:?}: {err}"))?;
-        let mut content = String::new();
-        file.read_to_string(&mut content)
-            .map_err(|err| format!("couldn't read {filename:?}: {err}"))?;
-        Ok(content)
+        std::fs::read_to_string(filename)
+            .map_err(|err| format!("couldn't read {filename:?}: {err}"))
     }
 
     fn read_stdin(&self) -> Result<String, String> {


### PR DESCRIPTION
`read_file` opened a `File`, allocated a `String` and read into it, which is what `fs::read_to_string` does in one call.

One user-visible consequence: the two error messages `couldn't open {path}: {err}` and `couldn't read {path}: {err}` collapse into the second, because a single call cannot tell an open failure from a read failure. The io::Error text still names the cause ("No such file or directory", "Is a directory", …), so nothing diagnostic is lost. No test asserts either string — the relevant ones are bare `#[should_panic]` with no message match.

`read_stdin` is untouched and still needs `use std::io::prelude::*`.

`cargo test -p mrml-cli` passes all 32 tests, including `missing_file` and the HTTP-include ones.