### PR TITLE
refactor(mrml-core): simplify the spacing and sort helpers

### DIFF
--- a/packages/mrml-core/src/helper/mod.rs
+++ b/packages/mrml-core/src/helper/mod.rs
@@ -1,8 +1,6 @@
 #[cfg(feature = "render")]
 pub mod size;
 #[cfg(feature = "render")]
-pub mod sort;
-#[cfg(feature = "render")]
 pub mod spacing;
 #[cfg(feature = "render")]
 pub mod style;

--- a/packages/mrml-core/src/helper/sort.rs
+++ b/packages/mrml-core/src/helper/sort.rs
@@ -1,5 +1,0 @@
-use std::cmp::Ordering;
-
-pub fn sort_by_key<V>(a: &(&String, V), b: &(&String, V)) -> Ordering {
-    a.0.cmp(b.0)
-}

--- a/packages/mrml-core/src/helper/spacing.rs
+++ b/packages/mrml-core/src/helper/spacing.rs
@@ -127,4 +127,26 @@ pub mod tests {
         assert_eq!(res.bottom(), Pixel::new(0.0));
         assert_eq!(res.left(), Pixel::new(20.0));
     }
+
+    // pin deliberate parser quirks
+    #[test]
+    fn tab_is_not_a_separator() {
+        let res = Spacing::try_from("2px\t4px");
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn double_space_fails_to_parse() {
+        let res = Spacing::try_from("2px  4px");
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn fifth_value_is_ignored() {
+        let res: Spacing = Spacing::try_from("1px 2px 3px 4px 5px").unwrap();
+        assert_eq!(res.top(), Pixel::new(1.0));
+        assert_eq!(res.right(), Pixel::new(2.0));
+        assert_eq!(res.bottom(), Pixel::new(3.0));
+        assert_eq!(res.left(), Pixel::new(4.0));
+    }
 }

--- a/packages/mrml-core/src/helper/spacing.rs
+++ b/packages/mrml-core/src/helper/spacing.rs
@@ -15,99 +15,23 @@ pub enum SpacingParserError {
 }
 
 /// representation of spacing
-pub enum Spacing {
-    Single(Pixel),
-    Two(Pixel, Pixel),
-    Three(Pixel, Pixel, Pixel),
-    Four(Pixel, Pixel, Pixel, Pixel),
-}
+pub struct Spacing([Pixel; 4]);
 
 impl Spacing {
-    #[cfg(test)]
-    pub fn top(&self) -> &Pixel {
-        match self {
-            Self::Single(top) => top,
-            Self::Two(vertical, _horizontal) => vertical,
-            Self::Three(top, _horizontal, _bottom) => top,
-            Self::Four(top, _right, _bottom, _left) => top,
-        }
+    pub fn top(&self) -> Pixel {
+        self.0[0]
     }
 
-    pub fn into_top(self) -> Pixel {
-        match self {
-            Self::Single(top) => top,
-            Self::Two(vertical, _horizontal) => vertical,
-            Self::Three(top, _horizontal, _bottom) => top,
-            Self::Four(top, _right, _bottom, _left) => top,
-        }
+    pub fn right(&self) -> Pixel {
+        self.0[1]
     }
 
-    pub fn right(&self) -> &Pixel {
-        match self {
-            Self::Single(top) => top,
-            Self::Two(_vertical, horizontal) => horizontal,
-            Self::Three(_top, horizontal, _bottom) => horizontal,
-            Self::Four(_top, right, _bottom, _left) => right,
-        }
+    pub fn bottom(&self) -> Pixel {
+        self.0[2]
     }
 
-    pub fn into_right(self) -> Pixel {
-        match self {
-            Self::Single(top) => top,
-            Self::Two(_vertical, horizontal) => horizontal,
-            Self::Three(_top, horizontal, _bottom) => horizontal,
-            Self::Four(_top, right, _bottom, _left) => right,
-        }
-    }
-
-    #[cfg(test)]
-    pub fn bottom(&self) -> &Pixel {
-        match self {
-            Self::Single(top) => top,
-            Self::Two(vertical, _horizontal) => vertical,
-            Self::Three(_top, _horizontal, bottom) => bottom,
-            Self::Four(_top, _right, bottom, _left) => bottom,
-        }
-    }
-
-    pub fn into_bottom(self) -> Pixel {
-        match self {
-            Self::Single(top) => top,
-            Self::Two(vertical, _horizontal) => vertical,
-            Self::Three(_top, _horizontal, bottom) => bottom,
-            Self::Four(_top, _right, bottom, _left) => bottom,
-        }
-    }
-
-    pub fn left(&self) -> &Pixel {
-        match self {
-            Self::Single(top) => top,
-            Self::Two(_vertical, horizontal) => horizontal,
-            Self::Three(_top, horizontal, _bottom) => horizontal,
-            Self::Four(_top, _right, _bottom, left) => left,
-        }
-    }
-
-    pub fn into_left(self) -> Pixel {
-        match self {
-            Self::Single(top) => top,
-            Self::Two(_vertical, horizontal) => horizontal,
-            Self::Three(_top, horizontal, _bottom) => horizontal,
-            Self::Four(_top, _right, _bottom, left) => left,
-        }
-    }
-}
-
-impl std::fmt::Display for Spacing {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Single(first) => write!(f, "{first}"),
-            Self::Two(first, second) => write!(f, "{first} {second}"),
-            Self::Three(first, second, third) => write!(f, "{first} {second} {third}"),
-            Self::Four(first, second, third, fourth) => {
-                write!(f, "{first} {second} {third} {fourth}")
-            }
-        }
+    pub fn left(&self) -> Pixel {
+        self.0[3]
     }
 }
 
@@ -122,21 +46,27 @@ impl TryFrom<&str> for Spacing {
             sections.next(),
             sections.next(),
         ) {
-            (Some(first), None, None, None) => Ok(Self::Single(Pixel::try_from(first)?)),
-            (Some(first), Some(second), None, None) => {
-                Ok(Self::Two(Pixel::try_from(first)?, Pixel::try_from(second)?))
+            (Some(first), None, None, None) => {
+                let first = Pixel::try_from(first)?;
+                Ok(Self([first, first, first, first]))
             }
-            (Some(first), Some(second), Some(third), None) => Ok(Self::Three(
-                Pixel::try_from(first)?,
-                Pixel::try_from(second)?,
-                Pixel::try_from(third)?,
-            )),
-            (Some(first), Some(second), Some(third), Some(four)) => Ok(Self::Four(
+            (Some(first), Some(second), None, None) => {
+                let first = Pixel::try_from(first)?;
+                let second = Pixel::try_from(second)?;
+                Ok(Self([first, second, first, second]))
+            }
+            (Some(first), Some(second), Some(third), None) => {
+                let first = Pixel::try_from(first)?;
+                let second = Pixel::try_from(second)?;
+                let third = Pixel::try_from(third)?;
+                Ok(Self([first, second, third, second]))
+            }
+            (Some(first), Some(second), Some(third), Some(four)) => Ok(Self([
                 Pixel::try_from(first)?,
                 Pixel::try_from(second)?,
                 Pixel::try_from(third)?,
                 Pixel::try_from(four)?,
-            )),
+            ])),
             _ => Err(SpacingParserError::Empty),
         }
     }
@@ -150,7 +80,7 @@ pub mod tests {
     #[test]
     fn single_value() {
         let res: Spacing = Spacing::try_from("1px").unwrap();
-        assert_eq!(res.top(), &Pixel::new(1.0));
+        assert_eq!(res.top(), Pixel::new(1.0));
         assert_eq!(res.top(), res.bottom());
         assert_eq!(res.top(), res.right());
         assert_eq!(res.right(), res.left());
@@ -159,28 +89,28 @@ pub mod tests {
     #[test]
     fn two_values() {
         let res: Spacing = Spacing::try_from("2px 4px").unwrap();
-        assert_eq!(res.top(), &Pixel::new(2.0));
+        assert_eq!(res.top(), Pixel::new(2.0));
         assert_eq!(res.top(), res.bottom());
-        assert_eq!(res.left(), &Pixel::new(4.0));
+        assert_eq!(res.left(), Pixel::new(4.0));
         assert_eq!(res.left(), res.right());
     }
 
     #[test]
     fn three_values() {
         let res: Spacing = Spacing::try_from("2px 3px 4px").unwrap();
-        assert_eq!(res.top(), &Pixel::new(2.0));
-        assert_eq!(res.right(), &Pixel::new(3.0));
+        assert_eq!(res.top(), Pixel::new(2.0));
+        assert_eq!(res.right(), Pixel::new(3.0));
         assert_eq!(res.left(), res.right());
-        assert_eq!(res.bottom(), &Pixel::new(4.0));
+        assert_eq!(res.bottom(), Pixel::new(4.0));
     }
 
     #[test]
     fn four_values() {
         let res: Spacing = Spacing::try_from("2px 3px 4px 5px").unwrap();
-        assert_eq!(res.top(), &Pixel::new(2.0));
-        assert_eq!(res.right(), &Pixel::new(3.0));
-        assert_eq!(res.bottom(), &Pixel::new(4.0));
-        assert_eq!(res.left(), &Pixel::new(5.0));
+        assert_eq!(res.top(), Pixel::new(2.0));
+        assert_eq!(res.right(), Pixel::new(3.0));
+        assert_eq!(res.bottom(), Pixel::new(4.0));
+        assert_eq!(res.left(), Pixel::new(5.0));
     }
 
     #[test]
@@ -192,9 +122,9 @@ pub mod tests {
     #[test]
     fn unitless_zero() {
         let res: Spacing = Spacing::try_from("20px 20px 0 20px").unwrap();
-        assert_eq!(res.top(), &Pixel::new(20.0));
-        assert_eq!(res.right(), &Pixel::new(20.0));
-        assert_eq!(res.bottom(), &Pixel::new(0.0));
-        assert_eq!(res.left(), &Pixel::new(20.0));
+        assert_eq!(res.top(), Pixel::new(20.0));
+        assert_eq!(res.right(), Pixel::new(20.0));
+        assert_eq!(res.bottom(), Pixel::new(0.0));
+        assert_eq!(res.left(), Pixel::new(20.0));
     }
 }

--- a/packages/mrml-core/src/mj_head/render.rs
+++ b/packages/mrml-core/src/mj_head/render.rs
@@ -1,5 +1,4 @@
 use super::MjHead;
-use crate::helper::sort::sort_by_key;
 use crate::mj_style::StyleInlineMode;
 use crate::prelude::hash::Map;
 use crate::prelude::render::*;
@@ -199,7 +198,7 @@ impl Renderer<'_, MjHead, ()> {
             return;
         }
         let mut classnames = cursor.header.media_queries().iter().collect::<Vec<_>>();
-        classnames.sort_by(sort_by_key);
+        classnames.sort_by(|a, b| a.0.cmp(b.0));
         let breakpoint = self.context.header.breakpoint().to_string();
         cursor.buffer.push_str("<style type=\"text/css\">");
         cursor.buffer.push_str("@media only screen and (min-width:");

--- a/packages/mrml-core/src/prelude/render/mod.rs
+++ b/packages/mrml-core/src/prelude/render/mod.rs
@@ -143,39 +143,33 @@ pub(crate) trait Render<'root> {
     }
 
     fn get_inner_border_left(&self) -> Option<Pixel> {
-        self.attribute_as_pixel("inner-border-left").or_else(|| {
-            self.attribute_as_spacing("inner-border")
-                .map(|s| s.into_left())
-        })
+        self.attribute_as_pixel("inner-border-left")
+            .or_else(|| self.attribute_as_spacing("inner-border").map(|s| s.left()))
     }
 
     fn get_inner_border_right(&self) -> Option<Pixel> {
-        self.attribute_as_pixel("inner-border-right").or_else(|| {
-            self.attribute_as_spacing("inner-border")
-                .map(|s| s.into_right())
-        })
+        self.attribute_as_pixel("inner-border-right")
+            .or_else(|| self.attribute_as_spacing("inner-border").map(|s| s.right()))
     }
 
     fn get_padding_top(&self) -> Option<Pixel> {
         self.attribute_as_pixel("padding-top")
-            .or_else(|| self.attribute_as_spacing("padding").map(|s| s.into_top()))
+            .or_else(|| self.attribute_as_spacing("padding").map(|s| s.top()))
     }
 
     fn get_padding_bottom(&self) -> Option<Pixel> {
-        self.attribute_as_pixel("padding-bottom").or_else(|| {
-            self.attribute_as_spacing("padding")
-                .map(|s| s.into_bottom())
-        })
+        self.attribute_as_pixel("padding-bottom")
+            .or_else(|| self.attribute_as_spacing("padding").map(|s| s.bottom()))
     }
 
     fn get_padding_left(&self) -> Option<Pixel> {
         self.attribute_as_pixel("padding-left")
-            .or_else(|| self.attribute_as_spacing("padding").map(|s| s.into_left()))
+            .or_else(|| self.attribute_as_spacing("padding").map(|s| s.left()))
     }
 
     fn get_padding_right(&self) -> Option<Pixel> {
         self.attribute_as_pixel("padding-right")
-            .or_else(|| self.attribute_as_spacing("padding").map(|s| s.into_right()))
+            .or_else(|| self.attribute_as_spacing("padding").map(|s| s.right()))
     }
 
     fn get_padding_horizontal(&self) -> Pixel {


### PR DESCRIPTION
Two internal helpers in `mrml-core`. `mod helper` is private, so none of this is reachable from outside the crate and no API changes.

**Spacing.** It was a four-variant enum (`Single`/`Two`/`Three`/`Four`) with eight accessors — `top`/`into_top`, `right`/`into_right` and so on — each a four-arm match, which is 32 arms spelling out the CSS shorthand rules over and over. Doing the expansion once at parse time makes it `Spacing([Pixel; 4])` and turns every accessor into an array index:

    1 value    [a]        -> [a, a, a, a]
    2 values   [a, b]     -> [a, b, a, b]
    3 values   [a, b, c]  -> [a, b, c, b]
    4 values   as given

The parse structure is untouched on purpose — still `split(' ')`, still four `next()` calls matched as a tuple, same error arms. So the quirks stay: a tab is not a separator, a double space fails, a fifth value is ignored. Those three had no coverage, so they now have characterization tests; that is the third commit.

`impl Display for Spacing` is gone. It had no caller anywhere.

Accessors return `Pixel` by value now (it is `Copy`), which is why the `.or_else` blocks in `prelude/render/mod.rs` reflow — rustfmt fits them on two lines once the names get shorter.

**sort.** `helper/sort.rs` was a five-line comparator with exactly one caller, so it is inlined as a closure at that call site and the module is deleted.

Net: 132 lines out, 48 in. Rendered output is unchanged — the golden HTML tests are the check that matters here, and they pass, along with fmt, check and clippy under `-Dwarnings`. mrml-core unit tests go 617 -> 620 with the new cases.