### PR TITLE
refactor(mrml-core): remove unused loader mutator methods

### DIFF
--- a/packages/mrml-core/src/prelude/parser/multi_loader.rs
+++ b/packages/mrml-core/src/prelude/parser/multi_loader.rs
@@ -100,25 +100,6 @@ impl<T> MultiIncludeLoader<T> {
             loader,
         )
     }
-
-    fn add_item(&mut self, filter: MultiIncludeLoaderFilter, loader: T) {
-        self.0.push(MultiIncludeLoaderItem { filter, loader });
-    }
-
-    #[inline]
-    pub fn add_any(&mut self, loader: T) {
-        self.add_item(MultiIncludeLoaderFilter::Any, loader);
-    }
-
-    #[inline]
-    pub fn add_starts_with<S: ToString>(&mut self, starts_with: S, loader: T) {
-        self.add_item(
-            MultiIncludeLoaderFilter::StartsWith {
-                value: starts_with.to_string(),
-            },
-            loader,
-        );
-    }
 }
 
 #[derive(Debug)]
@@ -237,9 +218,9 @@ mod tests {
         use crate::prelude::parser::multi_loader::MultiIncludeLoader;
         use crate::prelude::parser::noop_loader::NoopIncludeLoader;
 
-        let mut resolver = MultiIncludeLoader::default();
-        resolver.add_starts_with("foo", Box::<NoopIncludeLoader>::default());
-        resolver.add_any(Box::<NoopIncludeLoader>::default());
+        let resolver = MultiIncludeLoader::default()
+            .with_starts_with("foo", Box::<NoopIncludeLoader>::default())
+            .with_any(Box::<NoopIncludeLoader>::default());
         assert_eq!(resolver.0.len(), 2);
 
         assert_eq!(format!("{resolver:?}"), "MultiIncludeLoader([MultiIncludeLoaderItem { filter: StartsWith { value: \"foo\" }, loader: NoopIncludeLoader }, MultiIncludeLoaderItem { filter: Any, loader: NoopIncludeLoader }])");


### PR DESCRIPTION
**Breaking — for 7.0, not for a patch release.** `prelude::parser::multi_loader` is public.

`MultiIncludeLoader` carries two parallel APIs for the same job: the consuming builder (`with_item`, `with_any`, `with_starts_with`) and mutators (`add_item`, `add_any`, `add_starts_with`). The builder is what mrml-cli uses, what both doc examples use, and what the tests use. The mutators had no caller anywhere — the only thing reaching them was one unit test written to exercise them.

So the three mutators go. `should_build_resolvers` stays: it is rebuilt on the builder API and keeps both of its assertions, the item count and the exact `Debug` string. The coverage was worth keeping even though the API it exercised was not.

This is the smallest PR in the cleanup series — 22 lines — and on its own it is not worth a major version. It only makes sense bundled into a 7.0 that is happening anyway. Reasonable to close it if that is not on the cards.

For what it is worth, the counter-argument is that mutators support conditional construction without moving the loader, which the consuming builder makes awkward. Nothing in this repo does that, but a downstream user might.

fmt, check and clippy clean under `-Dwarnings`; tests stay at 617, and both doc examples still pass.