### PR TITLE
ci: refresh the apt index before installing cargo-llvm-cov

### DIFF
--- a/.github/workflows/mrml-core-main.yml
+++ b/.github/workflows/mrml-core-main.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   testing:
     runs-on: ubuntu-latest
-    container: rust:1-bullseye
+    container: rust:1-bookworm
 
     concurrency:
       group: ${{ github.ref }}-mrml-core-testing
@@ -50,6 +50,10 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-testing-${{ hashFiles('**/Cargo.lock') }}
+
+      # the image ships a prebaked apt index that 404s once versions are superseded
+      - name: refresh apt index
+        run: apt-get update
 
       - name: install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/mrml-wasm-main.yml
+++ b/.github/workflows/mrml-wasm-main.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   testing:
     runs-on: ubuntu-latest
-    container: rust:1-bullseye
+    container: rust:1-bookworm
 
     concurrency:
       group: ${{ github.ref }}-mrml-wasm-testing


### PR DESCRIPTION
The mrml-core `testing` job fails intermittently before compiling anything:

    Err:1 http://deb.debian.org/debian-security bullseye-security/main amd64 libjq1 amd64 1.6-2.1+deb11u3
      404  Not Found
    E: Unable to fetch some archives
    ##[error]Process completed with exit code 100

`taiki-e/install-action` apt-installs `jq`, and the `rust:1-*` images ship a prebaked apt index. Once a package version in that index is superseded on the mirror, the pinned `.deb` disappears and the install 404s. It looks transient because it only breaks after an upstream package update, and only on PRs touching `packages/mrml-core/**`.

My first guess was that this was bullseye being old, so I reproduced it in both images:

| image |  | after Reading package lists... |
|---|---|---|
| `rust:1-bullseye` | exit 100 | exit 0 |
| `rust:1-bookworm` | exit 100 | exit 0 |

So the Debian release is not the cause and bumping alone would have fixed nothing — the missing `apt-get update` is the cause. That is the one-step fix here. Steps share the container filesystem, so refreshing the index before the install step is enough.

I also moved both jobs from `rust:1-bullseye` to `rust:1-bookworm`, which is hygiene rather than the fix: bullseye is well past its regular support window, and the Dockerfile already builds on bookworm, so this stops CI and the image from drifting apart.

Only the wasm job's container changes; it installs node and wasm-pack without apt, so it needs no refresh step.